### PR TITLE
Only run actions on push, not pull_request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: github pages
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   deploy-landing-page:


### PR DESCRIPTION
Small change to not run actions on pull requests. I noticed one other issue as well where apache doesn't allow using the `ciiiii/toml-editor@1.0.0` action.

> Error : .github#L1
> ciiiii/toml-editor@1.0.0, ciiiii/toml-editor@1.0.0, ciiiii/toml-editor@1.0.0, and ciiiii/toml-editor@1.0.0 are not allowed to be used in apache/iceberg-docs. Actions in this workflow must be: within a repository owned by apache, created by GitHub, verified in the GitHub Marketplace or match the following: */*@[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]+, AdoptOpenJDK/install-jdk@*, JamesIves/github-pages-deploy-action@5dc1d5a192aeb5ab5b7d5a77b7d36aea4a7f5c92, TobKed/label-when-approved-action@*, actions-cool/issues-helper@*, actions-rs/*, al-cheb/configure-pagefile-action@*, amannn/action-semantic-pull-request@*, apache/*, burrunan/gradle-cache-action@*, bytedeco/javacpp-presets/.github/actions/*, chromaui/action@*, codecov/codecov-action@*, conda-incubator/setup-miniconda@*, container-tools/kind-action@*, container-tools/microshift-action@*, dawidd6/action-download-artifact@*, delaguardo/setup-graalvm@*, docker://pandoc/core:2.9, eps1lon/actions-label-merge-conflict@*,...

I'll look into that and provide an update in a follow-up PR.