### PR TITLE
Add javadoc link functionality to calculate /javadocs/<version>

### DIFF
--- a/docs/content/docs/api/javadocs/_index.md
+++ b/docs/content/docs/api/javadocs/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Javadocs"
+weight: 310
+javadocLink: true
+---

--- a/docs/layouts/partials/docs/menu-filetree.html
+++ b/docs/layouts/partials/docs/menu-filetree.html
@@ -57,6 +57,21 @@
             {{.Title}}
           </a>
         </li>
+        {{ else if .Params.javadocLink }}
+        <li
+          {{- if and (not .Params.BookFlatSection) (not .Params.BookCollapseSection) }}
+            class="navigation-icon-pad"
+          {{- else if  .Params.BookFlatSection }}
+            class="book-section-flat navigation-icon-pad"
+          {{- else if  .Params.BookCollapseSection }}
+            class="book-section-collapsed navigation-icon-pad"
+          {{ end -}}
+        >
+            <a href="{{ .Page.Site.BaseURL }}/../../javadocs/{{ .Page.Site.Params.versions.iceberg }}">
+              {{ template "book-nav-item-logo-image" (dict "Page" .) }}
+              {{.Title}}
+            </a>
+          </li>
       {{ else if .IsSection }}
         <li
           {{- if and (not .Page.Params.bookIconImage) (not .Page.Params.bookIconFa) }} class="book-section-flat navigation-icon-pad"


### PR DESCRIPTION
This includes a new front-matter setting `javadocLink` that is a boolean. The link to the javadocs is unique in that it requires a calculation on which javadoc version to link to based on the current version of the docs site the user is looking at. However, site params can't be used directly within front-matter.

So this PR achieves this using the logic in `menu-filetree.html` which is triggered when `javadocLink: true` and uses the following calculation to determine the javadoc site:
`{{ .Page.Site.BaseURL }}/../../javadocs/{{ .Page.Site.Params.versions.iceberg }}`.

As an example:

- A user is on `https://iceberg.apache.org/docs/0.12.1/spark-queries`
- Therefore, `{{ .Page.Site.BaseURL }}` resolves to `https://iceberg.apache.org/docs/0.12.1`
- Also, `{{ .Page.Site.Params.versions.iceberg }}` resolves to `0.12.1`
- So then `{{ .Page.Site.BaseURL }}/../../javadocs/{{ .Page.Site.Params.versions.iceberg }}` resolves to `https://iceberg.apache.org/docs/0.12.1/../../javadocs/0.12.1` which is `https://iceberg.apache.org/javadocs/0.12.1`