### PR TITLE
Remove link to 0.12.0 in side-navbar

### DIFF
--- a/docs/content/docs/releases/0.12.0/_index.md
+++ b/docs/content/docs/releases/0.12.0/_index.md
@@ -1,5 +1,0 @@
----
-title: "0.12.0"
-weight: 100
-bookUrlFromBaseURL: /0.12.0
----


### PR DESCRIPTION
This PR simply removes 0.12.0 from the left navbar since we'll be starting from 0.12.1 for the new versioned docs-site (with 0.13.0 soon to be added). I included 0.12.0 initially just to make sure the versioning is all working properly.