### PR TITLE
Fixing links now that common pages or part of the landing-page site

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -48,7 +48,7 @@ Iceberg was designed to solve correctness problems in eventually-consistent clou
 
 ### Open standard
 
-Iceberg has been designed and developed to be an open community standard with a [specification](spec) to ensure compatibility across languages and implementations.
+Iceberg has been designed and developed to be an open community standard with a [specification](../../spec) to ensure compatibility across languages and implementations.
 
-[Apache Iceberg is open source](community), and is developed at the [Apache Software Foundation](https://www.apache.org/).
+[Apache Iceberg is open source](../../community), and is developed at the [Apache Software Foundation](https://www.apache.org/).
 

--- a/docs/content/docs/api/java-api-quickstart.md
+++ b/docs/content/docs/api/java-api-quickstart.md
@@ -194,4 +194,4 @@ PartitionSpec spec = PartitionSpec.builderFor(schema)
       .build();
 ```
 
-For more information on the different partition transforms that Iceberg offers, visit [this page](../spec#partitioning).
+For more information on the different partition transforms that Iceberg offers, visit [this page](../../../spec#partitioning).

--- a/docs/content/docs/spark/spark-getting-started.md
+++ b/docs/content/docs/spark/spark-getting-started.md
@@ -24,7 +24,7 @@ aliases:
 
 # Getting Started
 
-The latest version of Iceberg is [{{% icebergVersion %}}](../releases).
+The latest version of Iceberg is [{{% icebergVersion %}}](../../../releases).
 
 Spark is currently the most feature-rich compute engine for Iceberg operations. 
 We recommend you to get started with Spark to understand Iceberg concepts and features with examples.

--- a/docs/content/docs/spark/spark-queries.md
+++ b/docs/content/docs/spark/spark-queries.md
@@ -244,7 +244,7 @@ SELECT * FROM prod.db.table.manifests
 ```
 
 Note: 
-1. Fields within `partition_summaries` column of the manifests table correspond to `field_summary` structs within [manifest list](../spec#manifest-lists), with the following order: 
+1. Fields within `partition_summaries` column of the manifests table correspond to `field_summary` structs within [manifest list](../../../spec#manifest-lists), with the following order: 
    - `contains_null`
    - `contains_nan`
    - `lower_bound`

--- a/docs/content/docs/tables/partitioning.md
+++ b/docs/content/docs/tables/partitioning.md
@@ -92,6 +92,6 @@ Because Iceberg doesn't require user-maintained partition columns, it can hide p
 
 Most importantly, queries no longer depend on a table's physical layout. With a separation between physical and logical, Iceberg tables can evolve partition schemes over time as data volume changes. Misconfigured tables can be fixed without an expensive migration.
 
-For details about all the supported hidden partition transformations, see the [Partition Transforms](../spec/#partition-transforms) section.
+For details about all the supported hidden partition transformations, see the [Partition Transforms](../../../spec/#partition-transforms) section.
 
 For details about updating a table's partition spec, see the [partition evolution](../evolution/#partition-evolution) section.

--- a/docs/content/docs/tables/reliability.md
+++ b/docs/content/docs/tables/reliability.md
@@ -26,7 +26,7 @@ Iceberg was designed to solve correctness problems that affect Hive tables runni
 
 Hive tables track data files using both a central metastore for partitions and a file system for individual files. This makes atomic changes to a table's contents impossible, and eventually consistent stores like S3 may return incorrect results due to the use of listing files to reconstruct the state of a table. It also requires job planning to make many slow listing calls: O(n) with the number of partitions.
 
-Iceberg tracks the complete list of data files in each [snapshot](../terms#snapshot) using a persistent tree structure. Every write or delete produces a new snapshot that reuses as much of the previous snapshot's metadata tree as possible to avoid high write volumes.
+Iceberg tracks the complete list of data files in each [snapshot](../../../terms#snapshot) using a persistent tree structure. Every write or delete produces a new snapshot that reuses as much of the previous snapshot's metadata tree as possible to avoid high write volumes.
 
 Valid snapshots in an Iceberg table are stored in the table metadata file, along with a reference to the current snapshot. Commits replace the path of the current table metadata file using an atomic operation. This ensures that all updates to table data and metadata are atomic, and is the basis for [serializable isolation](https://en.wikipedia.org/wiki/Isolation_(database_systems)#Serializable).
 


### PR DESCRIPTION
This fixes links to the common pages that broke when those pages were moved to the landing-page site. They now need to be prefixed with `../../` in order to back out of the versioned docs site.