### PR TITLE
Update javadoc links to include ../../

### DIFF
--- a/docs/content/docs/api/java-api-quickstart.md
+++ b/docs/content/docs/api/java-api-quickstart.md
@@ -26,7 +26,7 @@ aliases:
 
 ## Create a table
 
-Tables are created using either a [`Catalog`](../javadoc/master/index.html?org/apache/iceberg/catalog/Catalog.html) or an implementation of the [`Tables`](../javadoc/master/index.html?org/apache/iceberg/Tables.html) interface.
+Tables are created using either a [`Catalog`](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/catalog/Catalog.html) or an implementation of the [`Tables`](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/Tables.html) interface.
 
 ### Using a Hive catalog
 

--- a/docs/content/docs/api/java-api.md
+++ b/docs/content/docs/api/java-api.md
@@ -32,7 +32,7 @@ Table metadata and operations are accessed through the `Table` interface. This i
 
 ### Table metadata
 
-The [`Table` interface](../javadoc/master/index.html?org/apache/iceberg/Table.html) provides access to the table metadata:
+The [`Table` interface](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/Table.html) provides access to the table metadata:
 
 * `schema` returns the current table [schema](../schemas)
 * `spec` returns the current table partition spec
@@ -104,7 +104,7 @@ where `Record` is Iceberg record for iceberg-data module `org.apache.iceberg.dat
 
 ### Update operations
 
-`Table` also exposes operations that update the table. These operations use a builder pattern, [`PendingUpdate`](../javadoc/master/index.html?org/apache/iceberg/PendingUpdate.html), that commits when `PendingUpdate#commit` is called.
+`Table` also exposes operations that update the table. These operations use a builder pattern, [`PendingUpdate`](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/PendingUpdate.html), that commits when `PendingUpdate#commit` is called.
 
 For example, updating the table schema is done by calling `updateSchema`, adding updates to the builder, and finally calling `commit` to commit the pending changes to the table:
 
@@ -146,7 +146,7 @@ t.commitTransaction();
 
 ## Types
 
-Iceberg data types are located in the [`org.apache.iceberg.types` package](../javadoc/master/index.html?org/apache/iceberg/types/package-summary.html).
+Iceberg data types are located in the [`org.apache.iceberg.types` package](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/types/package-summary.html).
 
 ### Primitives
 
@@ -188,7 +188,7 @@ ListType list = ListType.ofRequired(1, IntegerType.get());
 
 ## Expressions
 
-Iceberg's expressions are used to configure table scans. To create expressions, use the factory methods in [`Expressions`](../javadoc/master/index.html?org/apache/iceberg/expressions/Expressions.html).
+Iceberg's expressions are used to configure table scans. To create expressions, use the factory methods in [`Expressions`](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/expressions/Expressions.html).
 
 Supported predicate expressions are:
 

--- a/docs/content/docs/flink/flink-getting-started.md
+++ b/docs/content/docs/flink/flink-getting-started.md
@@ -481,7 +481,7 @@ stream.print();
 env.execute("Test Iceberg Batch Read");
 ```
 
-There are other options that we could set by Java API, please see the [FlinkSource#Builder](../javadoc/{{% icebergVersion %}}/org/apache/iceberg/flink/source/FlinkSource.html).
+There are other options that we could set by Java API, please see the [FlinkSource#Builder](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/flink/source/FlinkSource.html).
 
 ## Writing with DataStream
 
@@ -545,7 +545,7 @@ RewriteDataFilesActionResult result = Actions.forTable(table)
         .execute();
 ```
 
-For more doc about options of the rewrite files action, please see [RewriteDataFilesAction](../javadoc/{{% icebergVersion %}}/org/apache/iceberg/flink/actions/RewriteDataFilesAction.html)
+For more doc about options of the rewrite files action, please see [RewriteDataFilesAction](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/flink/actions/RewriteDataFilesAction.html)
 
 ## Future improvement.
 

--- a/docs/content/docs/hive/_index.md
+++ b/docs/content/docs/hive/_index.md
@@ -141,8 +141,8 @@ SET iceberg.catalog.glue.lock.table=myGlueLockTable;
 ### CREATE EXTERNAL TABLE
 
 The `CREATE EXTERNAL TABLE` command is used to overlay a Hive table "on top of" an existing Iceberg table. 
-Iceberg tables are created using either a [`Catalog`](../javadoc/master/index.html?org/apache/iceberg/catalog/Catalog.html),
-or an implementation of the [`Tables`](../javadoc/master/index.html?org/apache/iceberg/Tables.html) interface,
+Iceberg tables are created using either a [`Catalog`](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/catalog/Catalog.html),
+or an implementation of the [`Tables`](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/Tables.html) interface,
 and Hive needs to be configured accordingly to operate on these different types of table.
 
 #### Hive catalog tables

--- a/docs/content/docs/spark/spark-procedures.md
+++ b/docs/content/docs/spark/spark-procedures.md
@@ -252,7 +252,7 @@ Rewrite manifests for a table to optimize scan planning.
 
 Data files in manifests are sorted by fields in the partition spec. This procedure runs in parallel using a Spark job.
 
-See the [`RewriteManifestsAction` Javadoc](../javadoc/{{% icebergVersion %}}/org/apache/iceberg/actions/RewriteManifestsAction.html)
+See the [`RewriteManifestsAction` Javadoc](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/actions/RewriteManifestsAction.html)
 to see more configuration options.
 
 **Note** this procedure invalidates all cached Spark plans that reference the affected table.

--- a/docs/content/docs/tables/maintenance.md
+++ b/docs/content/docs/tables/maintenance.md
@@ -31,7 +31,7 @@ Maintenance operations require the `Table` instance. Please refer [Java API quic
 
 Each write to an Iceberg table creates a new _snapshot_, or version, of a table. Snapshots can be used for time-travel queries, or the table can be rolled back to any valid snapshot.
 
-Snapshots accumulate until they are expired by the [`expireSnapshots`](../javadoc/{{% icebergVersion %}}/org/apache/iceberg/Table.html#expireSnapshots--) operation. Regularly expiring snapshots is recommended to delete data files that are no longer needed, and to keep the size of table metadata small.
+Snapshots accumulate until they are expired by the [`expireSnapshots`](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/Table.html#expireSnapshots--) operation. Regularly expiring snapshots is recommended to delete data files that are no longer needed, and to keep the size of table metadata small.
 
 This example expires snapshots that are older than 1 day:
 
@@ -43,7 +43,7 @@ table.expireSnapshots()
      .commit();
 ```
 
-See the [`ExpireSnapshots` Javadoc](../javadoc/{{% icebergVersion %}}/org/apache/iceberg/ExpireSnapshots.html) to see more configuration options.
+See the [`ExpireSnapshots` Javadoc](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/ExpireSnapshots.html) to see more configuration options.
 
 There is also a Spark action that can run table expiration in parallel for large tables:
 
@@ -89,7 +89,7 @@ Actions.forTable(table)
     .execute();
 ```
 
-See the [RemoveOrphanFilesAction Javadoc](../javadoc/{{% icebergVersion %}}/org/apache/iceberg/actions/RemoveOrphanFilesAction.html) to see more configuration options.
+See the [RemoveOrphanFilesAction Javadoc](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/actions/RemoveOrphanFilesAction.html) to see more configuration options.
 
 This action may take a long time to finish if you have lots of files in data and metadata directories. It is recommended to execute this periodically, but you may not need to execute this often.
 
@@ -126,7 +126,7 @@ Actions.forTable(table).rewriteDataFiles()
 
 The `files` metadata table is useful for inspecting data file sizes and determining when to compact partitons.
 
-See the [`RewriteDataFilesAction` Javadoc](../javadoc/{{% icebergVersion %}}/org/apache/iceberg/actions/RewriteDataFilesAction.html) to see more configuration options.
+See the [`RewriteDataFilesAction` Javadoc](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/actions/RewriteDataFilesAction.html) to see more configuration options.
 
 ### Rewrite manifests
 
@@ -146,4 +146,4 @@ table.rewriteManifests()
     .commit();
 ```
 
-See the [`RewriteManifestsAction` Javadoc](../javadoc/{{% icebergVersion %}}/org/apache/iceberg/actions/RewriteManifestsAction.html) to see more configuration options.
+See the [`RewriteManifestsAction` Javadoc](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/actions/RewriteManifestsAction.html) to see more configuration options.

--- a/landing-page/content/common/format/spec.md
+++ b/landing-page/content/common/format/spec.md
@@ -615,7 +615,7 @@ Each version of table metadata is stored in a metadata folder under the table’
 
 Notes:
 
-1. The file system table scheme is implemented in [HadoopTableOperations](../javadoc/master/index.html?org/apache/iceberg/hadoop/HadoopTableOperations.html).
+1. The file system table scheme is implemented in [HadoopTableOperations](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/hadoop/HadoopTableOperations.html).
 
 #### Metastore Tables
 
@@ -631,7 +631,7 @@ Each version of table metadata is stored in a metadata folder under the table’
 
 Notes:
 
-1. The metastore table scheme is partly implemented in [BaseMetastoreTableOperations](../javadoc/master/index.html?org/apache/iceberg/BaseMetastoreTableOperations.html).
+1. The metastore table scheme is partly implemented in [BaseMetastoreTableOperations](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/BaseMetastoreTableOperations.html).
 
 
 ### Delete Formats

--- a/landing-page/content/posts/format/spec.md
+++ b/landing-page/content/posts/format/spec.md
@@ -613,7 +613,7 @@ Each version of table metadata is stored in a metadata folder under the table’
 
 Notes:
 
-1. The file system table scheme is implemented in [HadoopTableOperations](../javadoc/master/index.html?org/apache/iceberg/hadoop/HadoopTableOperations.html).
+1. The file system table scheme is implemented in [HadoopTableOperations](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/hadoop/HadoopTableOperations.html).
 
 #### Metastore Tables
 
@@ -629,7 +629,7 @@ Each version of table metadata is stored in a metadata folder under the table’
 
 Notes:
 
-1. The metastore table scheme is partly implemented in [BaseMetastoreTableOperations](../javadoc/master/index.html?org/apache/iceberg/BaseMetastoreTableOperations.html).
+1. The metastore table scheme is partly implemented in [BaseMetastoreTableOperations](../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/BaseMetastoreTableOperations.html).
 
 
 ### Delete Formats


### PR DESCRIPTION
This fixes all of the javadoc links in the markdown files. Instead of explicitly pointing to `javadoc/master`, they now use the `{{% icebergVersion %}}` short-code to resolve to the version of the site the user is currently visiting. In other words if the user is on the `0.12.1` docs site, all of the javadoc links will point to the `javadoc/0.12.1` site.

Additionally, they all need to be prefixed with `../../` to back out of the versioned docs site.

Before example: `../javadoc/master/index.html?org/apache/iceberg/Table.html`
After example: `../../../javadoc/{{% icebergVersion %}}/index.html?org/apache/iceberg/Tables.html`