### PR TITLE
Continue to javadocs deployment on docs-site deployment failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
   deploy-docs:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-20.04
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       


### PR DESCRIPTION
As I started to look at adding the previous javadoc [versions](https://github.com/apache/iceberg/tree/asf-site/javadoc), I realized that they do not have accompanying docs sites (since the docs-site has never been versioned).

Structurally, this would mean we'd have a branch for each javadoc version (`0.7.0-incubating`, `0.8.0-incubating`, `0.9.0` etc) that would only have a `javadoc` directory but no `docs` directory.

Which brought me to the reason for this PR. Currently, the `deploy-javadoc` job waits on the completion of the `deploy-docs` job to avoid a race condition on committing to the `asf-site` branch. The problem though is that if there is no `docs` directory, the `deploy-docs` job will fail and the `deploy-javadoc` job won't run. This adds `continue-on-error: true` to the `deploy-docs` job so that if it fails (as it will for the `0.9.0` branch for example), the `deploy-javadoc` job will still run immediately after.

See this run as an example: https://github.com/samredai/iceberg-docs/actions/runs/1699473535
Which results in this directory getting created in the `asf-site` branch: https://github.com/samredai/iceberg-docs/tree/asf-site/javadoc/0.9.0
Which can be found at this url: https://iceberg.redai.dev/javadoc/0.9.0/