### PR TITLE
Replace toml action with simple sed command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,19 +13,15 @@ jobs:
         id: vars
         run: echo ::set-output name=branch_name::${GITHUB_REF#refs/*/}
 
-      - name: Set baseURL in config.toml
-        uses: ciiiii/toml-editor@1.0.0
-        with:
-          file: "landing-page/config.toml"
-          key: "baseURL"
-          value: "https://iceberg.apache.org/"
+      - name: Set baseURL in landing-page/config.toml
+        run: |
+          sed -i -e 's|baseURL = ""|baseURL = "https://iceberg\.apache\.org/"|g' landing-page/config.toml
+          cat landing-page/config.toml
 
-      - name: Set params.docsBaseURL in config.toml
-        uses: ciiiii/toml-editor@1.0.0
-        with:
-          file: "landing-page/config.toml"
-          key: "params.docsBaseURL"
-          value: "https://iceberg.apache.org/docs/${{ steps.vars.outputs.branch_name }}"
+      - name: Set params.docsBaseURL in landing-page/config.toml
+        run: |
+          sed -i -e 's|docsBaseURL = ""|docsBaseURL = "https://iceberg\.apache\.org/docs/${{ steps.vars.outputs.branch_name }}"|g' landing-page/config.toml
+          cat landing-page/config.toml
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
@@ -63,20 +59,16 @@ jobs:
         id: vars
         run: echo ::set-output name=branch_name::${GITHUB_REF#refs/*/}
 
-      - name: Set baseURL in config.toml
-        uses: ciiiii/toml-editor@1.0.0
-        with:
-          file: "docs/config.toml"
-          key: "baseURL"
-          value: "https://iceberg.apache.org/docs/${{ steps.vars.outputs.branch_name }}"
+      - name: Set baseURL in docs/config.toml
+        run: |
+          sed -i -e 's|baseURL = ""|baseURL = "https://iceberg\.apache\.org/docs/${{ steps.vars.outputs.branch_name }}"|g' docs/config.toml
+          cat docs/config.toml
 
-      - name: Set params.version in config.toml
-        uses: ciiiii/toml-editor@1.0.0
-        with:
-          file: "docs/config.toml"
-          key: "params.versions.iceberg"
-          value: "${{ steps.vars.outputs.branch_name }}"
-      
+      - name: Set params.versions.iceberg in docs/config.toml
+        run: |
+          sed -i -e 's|versions\.iceberg = ""|versions\.iceberg = "${{ steps.vars.outputs.branch_name }}"|g' docs/config.toml
+          cat docs/config.toml
+
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:

--- a/landing-page/config.toml
+++ b/landing-page/config.toml
@@ -5,6 +5,7 @@ title = "Apache Iceberg"
 [params]
   description = "The open table format for analytic datasets."
   latestVersions.iceberg = "0.12.1"
+  docsBaseURL = ""
 
 [[params.social]]
   title = "Community"


### PR DESCRIPTION
The builds are failing due to the toml editor action not being an action by github or a verified action. This replaces the action with a very simple sed command on the `config.toml` files.