### PR TITLE
Adds graphic for time-travel section of splash page

### DIFF
--- a/landing-page/content/services/time-travel.html
+++ b/landing-page/content/services/time-travel.html
@@ -22,15 +22,16 @@ weight: 400
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
-<div class="termynal-container">
+ <div class="termynal-container">
     <div id="termynal-time-travel" data-termynal data-ty-startDelay="600" data-ty-typeDelay="20" data-ty-lineDelay="500">
         <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">spark.read.table("taxis").count()</span>
         <span data-ty>2,853,020</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">val ONE_DAY_MS=86400000;</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">val ONE_DAY_MS=86400000</span>
         <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">val NOW=System.currentTimeMillis()</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">val YESTERDAY=NOW - ONE_DAY_MS</span>
         <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">(spark</span>
         <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.read</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.option("as-of-timestamp", NOW_MS - ONE_DAY_MS)</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.option("as-of-timestamp", YESTERDAY)</span>
         <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.table("taxis")</span>
         <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.count())</span>
         <span data-ty>2,798,371</span>

--- a/landing-page/content/services/time-travel.html
+++ b/landing-page/content/services/time-travel.html
@@ -1,5 +1,5 @@
 ---
-Title: Time Travel
+Title: Time Travel and Rollback
 Description: Time-travel enables reproducible queries that use exactly the same table snapshot, or lets users easily examine changes. Version rollback allows users to quickly correct problems by resetting tables to a good state.
 LearnMore: /docs/latest/spark-queries/#time-travel
 Category: Post

--- a/landing-page/content/services/time-travel.html
+++ b/landing-page/content/services/time-travel.html
@@ -1,9 +1,10 @@
 ---
 Title: Time Travel
-AsciinemaCast: time_travel.cast
+Description: Time-travel enables reproducible queries that use exactly the same table snapshot, or lets users easily examine changes. Version rollback allows users to quickly correct problems by resetting tables to a good state.
+LearnMore: /docs/latest/spark-queries/#time-travel
 Category: Post
 Draft: false
-weight: 300
+weight: 400
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more
@@ -21,6 +22,9 @@ weight: 300
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
- 
-Time-travel enables reproducible queries that use exactly the same table snapshot, or lets users easily examine changes.
-Version rollback allows users to quickly correct problems by resetting tables to a good state.
+ <div class="termynal-container">
+    <div id="termynal-time-travel" data-termynal data-ty-startDelay="600" data-ty-typeDelay="20" data-ty-lineDelay="500">
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">df_yesterday = spark.read.option("as-of-timestamp", System.currentTimeMillis() - ONE_DAY_MS).load("nyc.taxis")</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">df_two_days_ago = spark.read.option("as-of-timestamp", System.currentTimeMillis() - 2*ONE_DAY_MS).load("nyc.taxis")</span>
+    </div>
+</div>

--- a/landing-page/content/services/time-travel.html
+++ b/landing-page/content/services/time-travel.html
@@ -22,9 +22,17 @@ weight: 400
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
- <div class="termynal-container">
+<div class="termynal-container">
     <div id="termynal-time-travel" data-termynal data-ty-startDelay="600" data-ty-typeDelay="20" data-ty-lineDelay="500">
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">df_yesterday = spark.read.option("as-of-timestamp", System.currentTimeMillis() - ONE_DAY_MS).load("nyc.taxis")</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">df_two_days_ago = spark.read.option("as-of-timestamp", System.currentTimeMillis() - 2*ONE_DAY_MS).load("nyc.taxis")</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">spark.read.table("taxis").count()</span>
+        <span data-ty>2,853,020</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">val ONE_DAY_MS=86400000;</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">val NOW=System.currentTimeMillis()</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">(spark</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.read</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.option("as-of-timestamp", NOW_MS - ONE_DAY_MS)</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.table("taxis")</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.count())</span>
+        <span data-ty>2,798,371</span>
     </div>
 </div>

--- a/landing-page/static/css/landing-page.css
+++ b/landing-page/static/css/landing-page.css
@@ -217,3 +217,7 @@ a.page-scroll {
   		display:block !important;
 	}
 }
+
+.termynal-container {
+    padding-top: 3rem;
+}


### PR DESCRIPTION
This adds a timeline graphic for the Time Travel section feature description on the splash page.

<img width="1244" alt="Screen Shot 2022-01-26 at 8 03 10 AM" src="https://user-images.githubusercontent.com/43911210/151199750-9cb8332a-e7b9-4ab5-946e-f31b9f35ec78.png">

