### PR TITLE
Add Learn More buttons to the splash page and LearnMore integration into front-matter

### DIFF
--- a/landing-page/content/about/about.html
+++ b/landing-page/content/about/about.html
@@ -20,11 +20,12 @@ Draft: false
  -->
 
 Iceberg adds tables to compute engines including Spark, Trino, PrestoDB, Flink, and Hive using a high-performance table format that works just like a SQL table.
-
+<div class="button-box">
 <ul class="list-inline intro-social-buttons">
     <li>
         <a href="/getting-started" class="btn btn-default btn-lg">
             <span class="network-name">Learn More</span>
         </a>
     </li>
-</ul>
+<ul>
+</div>

--- a/landing-page/content/about/about.html
+++ b/landing-page/content/about/about.html
@@ -21,4 +21,10 @@ Draft: false
 
 Iceberg adds tables to compute engines including Spark, Trino, PrestoDB, Flink, and Hive using a high-performance table format that works just like a SQL table.
 
-[Learn More](/getting-started)
+<ul class="list-inline intro-social-buttons">
+    <li>
+        <a href="/getting-started" class="btn btn-default btn-lg">
+            <span class="network-name">Learn More</span>
+        </a>
+    </li>
+</ul>

--- a/landing-page/layouts/partials/services.html
+++ b/landing-page/layouts/partials/services.html
@@ -12,11 +12,25 @@
                     <hr class="section-heading-spacer">
                     <div class="clearfix"></div>
                     <h2 class="section-heading">{{ .Title }}</h2>
+                    {{ .Description }}
+                    {{ if .Params.LearnMore }}
+                    <ul class="list-inline intro-social-buttons">
+                        <li>
+                            <a href="{{ .Params.LearnMore }}" class="btn btn-default btn-lg">
+                                <span class="network-name">Learn More</span>
+                            </a>
+                        </li>
+                    </ul>
+                    {{ end }}
+                </div>
+                {{ if .Content }}
+                <div class="col-lg-5 col-lg col-sm-6">
                     {{ .Content }}
                 </div>
-                {{ with .Params.img }}
+                {{ end }}
+                {{ if .Params.Img }}
                 <div class="col-lg-5 col-lg-offset-2 col-sm-6">
-                    <img class="img-responsive" src="{{ $.Site.BaseURL }}/img/{{ . }}" alt="">
+                    <img src="{{ $.Site.BaseURL }}img/{{ .Params.Img }}" height="400px" width="400px">
                 </div>
                 {{ end }}
                 {{ if .Params.asciinemacast }}
@@ -49,11 +63,25 @@
                     <hr class="section-heading-spacer">
                     <div class="clearfix"></div>
                     <h2 class="section-heading">{{ .Title }}</h2>
-                    {{ .Content }}
+                    {{ .Description }}
+                    {{ if .Params.LearnMore }}
+                    <ul class="list-inline intro-social-buttons">
+                        <li>
+                            <a href="{{ .Params.LearnMore }}" class="btn btn-default btn-lg">
+                                <span class="network-name">Learn More</span>
+                            </a>
+                        </li>
+                    </ul>
+                    {{ end }}
                 </div>
-                {{ with .Params.img }}
+                {{ if .Content }}
                 <div class="col-lg-5 col-sm-pull-6  col-sm-6">
-                  <img class="img-responsive" src="{{ $.Site.BaseURL }}/img/{{ . }}" alt="">
+                  {{ .Content }}
+                </div>
+                {{ end }}
+                {{ if .Params.Img }}
+                <div class="col-lg-5 col-sm-pull-6  col-sm-6">
+                    <img src="{{ $.Site.BaseURL }}img/{{ .Params.Img }}" height="600px" width="600px">
                 </div>
                 {{ end }}
                 {{ if .Params.asciinemacast }}

--- a/landing-page/static/css/landing-page.css
+++ b/landing-page/static/css/landing-page.css
@@ -58,6 +58,10 @@ h6 {
     text-shadow: 2px 2px 3px rgba(0,0,0,0.6);
 }
 
+.button-box {
+    padding-top: 1rem;
+}
+
 @media(max-width:767px) {
     .intro-message {
         padding-bottom: 15%;


### PR DESCRIPTION
This makes the "Learn More" button an actual styled button and also adds the front-matter functionality for the landing-page to allow "LearnMore: /a/relative/url/path" to the landing-page features to allow easily adding a button that goes to the right section of the docs.

<img width="1298" alt="Screen Shot 2022-01-26 at 8 02 39 AM" src="https://user-images.githubusercontent.com/43911210/151199652-021079cc-c305-4964-b29e-c1913103f1ee.png">

