### PR TITLE
Ordering and termynal instantiations and adjustments

### DIFF
--- a/landing-page/content/services/data-compaction.html
+++ b/landing-page/content/services/data-compaction.html
@@ -3,7 +3,7 @@ Title: Data Compaction
 Description: Data compaction is supported out-of-the-box and you can choose from different rewrite strategies such as bin-packing or sorting to optimize file layout and size.
 Category: Services
 Draft: false
-weight: 300
+weight: 500
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more
@@ -21,6 +21,6 @@ weight: 300
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
- <div id="termynal-data-compaction" data-termynal data-ty-startDelay="600" data-ty-typeDelay="20" data-ty-lineDelay="500">
+ <div id="termynal-data-compaction" data-termynal data-ty-startDelay="8000" data-ty-typeDelay="20" data-ty-lineDelay="500">
     <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="spark-sql>">CALL system.rewrite_data_files("nyc.taxis");</span>
 </div>

--- a/landing-page/content/services/expressive-sql.html
+++ b/landing-page/content/services/expressive-sql.html
@@ -4,7 +4,7 @@ Description: Iceberg supports flexible SQL commands to merge new data, update ex
 <!-- LearnMore: /docs/latest/row-level-deletes -->
 Category: Services
 Draft: false
-weight: 300
+weight: 100
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more
@@ -22,7 +22,7 @@ weight: 300
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
- <div id="termynal-expressive-sql" data-termynal data-ty-startDelay="600" data-ty-typeDelay="20" data-ty-lineDelay="500">
+ <div id="termynal-expressive-sql" data-termynal data-ty-startDelay="2000" data-ty-typeDelay="20" data-ty-lineDelay="500">
     <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="spark-sql>">MERGE INTO prod.nyc.taxis pt</span>
     <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">USING (SELECT * FROM staging.nyc.taxis) st</span>
     <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">ON pt.id = st.id</span>

--- a/landing-page/content/services/hidden-partitioning.html
+++ b/landing-page/content/services/hidden-partitioning.html
@@ -5,7 +5,7 @@ LottieFile: hidden-partitioning-animation.json
 LearnMore: /docs/latest/partitioning/#icebergs-hidden-partitioning
 Category: Services
 Draft: false
-weight: 200
+weight: 300
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/landing-page/content/services/schema-evolution.html
+++ b/landing-page/content/services/schema-evolution.html
@@ -4,7 +4,7 @@ Description: Iceberg avoids unpleasant surprises. Schema evolution just works wi
 LearnMore: /docs/latest/evolution/
 Category: Services
 Draft: false
-weight: 100
+weight: 200
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more
@@ -22,7 +22,7 @@ weight: 100
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
-<div id="termynal" data-termynal data-ty-startDelay="600" data-ty-typeDelay="20" data-ty-lineDelay="500">
+<div id="termynal" data-termynal data-ty-startDelay="4000" data-ty-typeDelay="20" data-ty-lineDelay="500">
     <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="spark-sql>">ALTER TABLE taxis</span>
     <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">ALTER COLUMN trip_distance</span>
     <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="" data-ty-delay="2500">TYPE double;</span>

--- a/landing-page/content/services/time-travel.html
+++ b/landing-page/content/services/time-travel.html
@@ -23,7 +23,7 @@ weight: 400
  - limitations under the License.
  -->
  <div class="termynal-container">
-    <div id="termynal-time-travel" data-termynal data-ty-startDelay="600" data-ty-typeDelay="20" data-ty-lineDelay="500">
+    <div id="termynal-time-travel" data-termynal data-ty-startDelay="6000" data-ty-typeDelay="20" data-ty-lineDelay="500">
         <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">spark.read.table("taxis").count()</span>
         <span data-ty>2,853,020</span>
         <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">val ONE_DAY_MS=86400000</span>

--- a/landing-page/layouts/partials/js.html
+++ b/landing-page/layouts/partials/js.html
@@ -11,7 +11,7 @@
 <script src="{{ .Site.BaseURL }}/js/landing-page.js"></script>
 
 <!-- Termynal animation renderer -->
-<script src="{{ .Site.BaseURL }}/js/termynal.js" data-termynal-container="#termynal"></script>
+<script src="{{ .Site.BaseURL }}/js/termynal.js" data-termynal-container="#termynal|#termynal-data-compaction|#termynal-expressive-sql|#termynal-time-travel"></script>
 
 {{ if isset .Site.Params "googleAnalytics" }}
 


### PR DESCRIPTION
This makes a 3 main adjustments:
- Re-orders the highlights on the landing-page to the order suggested [here](https://github.com/apache/iceberg-docs/pull/18#issuecomment-1022444819)
- Add's termynal instances for each termynal example (this is power by the html objects id, the relevant line is [here](https://github.com/apache/iceberg-docs/pull/23/files#diff-38b164ac00c27a708cbb72d9b3ef4f69e4b4e7591847a217c6fd29c51afa1287R14) and this is explained in the termynal.js docs [here](https://github.com/ines/termynal#usage))
- This also updates the delay so that all of the termynal examples don't start at the same time but cascade a delay by a few seconds. That makes the examples run more naturally as you scroll (see the video below)

https://user-images.githubusercontent.com/43911210/151874549-dcf920a9-87bf-4f06-9c90-33ec0c2688c3.mp4


