### PR TITLE
Add LearnMore link for Expressive SQL display

### DIFF
--- a/landing-page/content/services/expressive-sql.html
+++ b/landing-page/content/services/expressive-sql.html
@@ -1,7 +1,7 @@
 ---
 Title: Expressive SQL
 Description: Iceberg supports flexible SQL commands to merge new data, update existing rows, and perform targeted deletes. Iceberg can eagerly rewrite data files for read performance, or it can use delete deltas for faster updates.
-<!-- LearnMore: /docs/latest/row-level-deletes -->
+LearnMore: /docs/latest/spark-writes/
 Category: Services
 Draft: false
 weight: 300


### PR DESCRIPTION
This adds a LearnMore button for the Expressive SQL section of the landing-page. It links to the Spark Writes section.