### PR TITLE
Add 0.13.0 to left navbar

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -8,5 +8,5 @@ theme= "hugo-book"
   BookLogo = "img/iceberg-logo-icon.png"
   versions.iceberg = "" # This is populated by the github deploy workflow and is equal to the branch name
   versions.nessie = "0.17.0"
-  latestVersions.iceberg = "0.12.1"  # This is used for the version badge on the "latest" site version
+  latestVersions.iceberg = "0.13.0"  # This is used for the version badge on the "latest" site version
   BookSection='docs' # This determines which directory will inform the left navigation menu

--- a/docs/content/docs/releases/0.13.0/_index.md
+++ b/docs/content/docs/releases/0.13.0/_index.md
@@ -1,0 +1,5 @@
+---
+title: "0.13.0"
+weight: 98
+bookUrlFromBaseURL: /0.13.0
+---

--- a/docs/content/docs/releases/latest/_index.md
+++ b/docs/content/docs/releases/latest/_index.md
@@ -1,5 +1,5 @@
 ---
 title: "Latest"
-weight: 98
+weight: 1
 bookUrlFromBaseURL: /latest
 ---


### PR DESCRIPTION
This adds `0.13.0` to the Releases drop-down on the 0.13.0 docs site. This is something we'll have to do on every release. This might be a point of discussion so let me try and explain this behavior.

Since previous docs-site versions will never be touched on subsequent version releases, the "Releases" drop-down won't have versions above the version of the current docs-site you're looking at. The "latest" link never changes so any versioned docs site will have a link to latest.

- You're on 0.13.0
  - You see the following:
    - Latest (currently takes you to 0.13.0)
    - 0.13.0
    - 0.12.1

- You're on 0.12.1
  - You see the following:
    - Latest (currently takes you to 0.13.0)
    - 0.12.1

In the future when we have 0.13.5 as an example:
- You're on 0.13.5
  - You see the following:
    - Latest (currently takes you to 0.13.0)
    - 0.13.5
    - 0.13.4
    - 0.13.3

We should agree on how many previous versions (relative to the current version in view) we should show. I think latest + 3 versions feels right. So `latest`, `current`, `current-1`, and `current-2`.
