### PR TITLE
Publish site: Add .asf.yaml to root of asf-site branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# The format of this file is documented at
+# https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+
+github:
+  description: "Apache Iceberg Documentation Site"
+  homepage: https://iceberg.apache.org/
+  labels:
+    - iceberg
+    - apache
+    - docs
+
+notifications:
+    commits:      commits@iceberg.apache.org
+    issues:       issues@iceberg.apache.org
+    pullrequests: issues@iceberg.apache.org
+
+publish:
+    whoami:  asf-site


### PR DESCRIPTION
This adds the `.asf.yaml` file with the publish declaration to the root of the `asf-site` branch. This should trigger the release of the new site to https://iceberg.apache.org.