### PR TITLE
Fix weights for landing-page for left/right alternations

### DIFF
--- a/landing-page/content/services/data-compaction.html
+++ b/landing-page/content/services/data-compaction.html
@@ -3,7 +3,7 @@ Title: Data Compaction
 Description: Data compaction is supported out-of-the-box and you can choose from different rewrite strategies such as bin-packing or sorting to optimize file layout and size.
 Category: Services
 Draft: false
-weight: 500
+weight: 5
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/landing-page/content/services/expressive-sql.html
+++ b/landing-page/content/services/expressive-sql.html
@@ -4,7 +4,7 @@ Description: Iceberg supports flexible SQL commands to merge new data, update ex
 LearnMore: /docs/latest/spark-writes/
 Category: Services
 Draft: false
-weight: 100
+weight: 1
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/landing-page/content/services/hidden-partitioning.html
+++ b/landing-page/content/services/hidden-partitioning.html
@@ -5,7 +5,7 @@ LottieFile: hidden-partitioning-animation.json
 LearnMore: /docs/latest/partitioning/#icebergs-hidden-partitioning
 Category: Services
 Draft: false
-weight: 300
+weight: 3
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/landing-page/content/services/schema-evolution.html
+++ b/landing-page/content/services/schema-evolution.html
@@ -4,7 +4,7 @@ Description: Schema evolution just works. Adding a column won't bring back "zomb
 LearnMore: /docs/latest/evolution/
 Category: Services
 Draft: false
-weight: 200
+weight: 2
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/landing-page/content/services/time-travel.html
+++ b/landing-page/content/services/time-travel.html
@@ -4,7 +4,7 @@ Description: Time-travel enables reproducible queries that use exactly the same 
 LearnMore: /docs/latest/spark-queries/#time-travel
 Category: Post
 Draft: false
-weight: 400
+weight: 4
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
The theme has some logic that alternates the items on the landing-page based on the weights. It uses [modBool](https://gohugo.io/functions/math/) from hugo and for some reason seems to break with larger numbers. Using simpler digits here fixes it.

cc: @rdblue 