### PR TITLE
Adding all root level redirects to latest docs site url

### DIFF
--- a/redirects/api/index.html
+++ b/redirects/api/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/api'" />
 </head>

--- a/redirects/aws/index.html
+++ b/redirects/aws/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/aws'" />
 </head>

--- a/redirects/configuration/index.html
+++ b/redirects/configuration/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/configuration'" />
 </head>

--- a/redirects/custom-catalog/index.html
+++ b/redirects/custom-catalog/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/custom-catalog'" />
 </head>

--- a/redirects/evolution/index.html
+++ b/redirects/evolution/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/evolution'" />
 </head>

--- a/redirects/flink-connector/index.html
+++ b/redirects/flink-connector/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/flink-connector'" />
 </head>

--- a/redirects/flink/index.html
+++ b/redirects/flink/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/flink'" />
 </head>

--- a/redirects/hive/index.html
+++ b/redirects/hive/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/hive'" />
 </head>

--- a/redirects/java-api-quickstart/index.html
+++ b/redirects/java-api-quickstart/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/java-api-quickstart'" />
 </head>

--- a/redirects/javadoc/index.html
+++ b/redirects/javadoc/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/javadoc/latest'" />
 </head>

--- a/redirects/jdbc/index.html
+++ b/redirects/jdbc/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/jdbc'" />
 </head>

--- a/redirects/maintenance/index.html
+++ b/redirects/maintenance/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/maintenance'" />
 </head>

--- a/redirects/nessie/index.html
+++ b/redirects/nessie/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/nessie'" />
 </head>

--- a/redirects/partitioning/index.html
+++ b/redirects/partitioning/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/partitioning'" />
 </head>

--- a/redirects/performance/index.html
+++ b/redirects/performance/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/performance'" />
 </head>

--- a/redirects/python-api-intro/index.html
+++ b/redirects/python-api-intro/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/python-api-intro'" />
 </head>

--- a/redirects/python-feature-support/index.html
+++ b/redirects/python-feature-support/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/python-feature-support'" />
 </head>

--- a/redirects/python-quickstart/index.html
+++ b/redirects/python-quickstart/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/python-quickstart'" />
 </head>

--- a/redirects/reliability/index.html
+++ b/redirects/reliability/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/reliability'" />
 </head>

--- a/redirects/schemas/index.html
+++ b/redirects/schemas/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/schemas'" />
 </head>

--- a/redirects/spark-configuration/index.html
+++ b/redirects/spark-configuration/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/spark-configuration'" />
 </head>

--- a/redirects/spark-ddl/index.html
+++ b/redirects/spark-ddl/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/spark-ddl'" />
 </head>

--- a/redirects/spark-procedures/index.html
+++ b/redirects/spark-procedures/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/spark-procedures'" />
 </head>

--- a/redirects/spark-queries/index.html
+++ b/redirects/spark-queries/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/spark-queries'" />
 </head>

--- a/redirects/spark-structured-streaming/index.html
+++ b/redirects/spark-structured-streaming/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/latest'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/spark-structured-streaming'" />
 </head>

--- a/redirects/spark-writes/index.html
+++ b/redirects/spark-writes/index.html
@@ -15,5 +15,5 @@
  - limitations under the License.
  -->
 <head>
-  <meta http-equiv="Refresh" content="0; url='/docs/0.12.1'" />
+  <meta http-equiv="Refresh" content="0; url='/docs/latest/spark-writes'" />
 </head>


### PR DESCRIPTION
This adds a set of root level redirects from paths on the old un-versioned site to redirect to the same page on the `latest` docs site version.