### PR TITLE
Adding Spec Link To Landing Page Header

### DIFF
--- a/landing-page/layouts/partials/header.html
+++ b/landing-page/layouts/partials/header.html
@@ -19,6 +19,9 @@
                     <a class="page-scroll" href="{{ .Site.BaseURL }}docs/latest">Docs</a>
                 </li>
                 <li>
+                    <a class="page-scroll" href="{{ .Site.BaseURL }}spec">Spec</a>
+                </li>
+                <li>
                     <a class="page-scroll" href="{{ .Site.BaseURL }}docs/latest/getting-started/">Spark</a>
                 </li>
                 <li>


### PR DESCRIPTION
Just like any other specification like GraphQL or Open Spec API, taking the developers to the Spec page will be super convenient by having a dedicated Spec tab in the landing screen. 
![image](https://user-images.githubusercontent.com/99108527/153741230-5109b1a7-d679-4e5c-b9fc-9f4b6a8f8619.png)
