### PR TITLE
Docs: Update documentation for 0.13.1 release

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -8,5 +8,5 @@ theme= "hugo-book"
   BookLogo = "img/iceberg-logo-icon.png"
   versions.iceberg = "" # This is populated by the github deploy workflow and is equal to the branch name
   versions.nessie = "0.18.0"
-  latestVersions.iceberg = "0.13.0"  # This is used for the version badge on the "latest" site version
+  latestVersions.iceberg = "0.13.1"  # This is used for the version badge on the "latest" site version
   BookSection='docs' # This determines which directory will inform the left navigation menu

--- a/docs/content/docs/community/blogs.md
+++ b/docs/content/docs/community/blogs.md
@@ -1,5 +1,6 @@
 ---
 title: "Blogs"
+weight: 200
 bookUrlFromBaseURL: /../../blogs
 ---
 <!--

--- a/docs/content/docs/community/contribute.md
+++ b/docs/content/docs/community/contribute.md
@@ -1,7 +1,7 @@
 ---
-title: "Join"
-weight: 100
-bookUrlFromBaseURL: /../../community
+title: "Contribute"
+weight: 400
+bookUrlFromBaseURL: /../../contribute
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/content/docs/community/talks.md
+++ b/docs/content/docs/community/talks.md
@@ -1,6 +1,7 @@
 ---
 title: "Talks"
 bookUrlFromBaseURL: /../../talks
+weight: 300
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/content/docs/project/multi-engine-support.md
+++ b/docs/content/docs/project/multi-engine-support.md
@@ -1,7 +1,6 @@
 ---
-title: "Join"
-weight: 100
-bookUrlFromBaseURL: /../../community
+title: "Multi-Engine Support"
+bookUrlFromBaseURL: /../../multi-engine-support
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/content/docs/spark/spark-getting-started.md
+++ b/docs/content/docs/spark/spark-getting-started.md
@@ -39,7 +39,7 @@ spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:{{% ice
 ```
 
 {{< hint info >}}
-If you want to include Iceberg in your Spark installation, add the [`iceberg-spark-runtime-3.2_2.12` Jar][spark-runtime-jar] to Spark's `jars` folder.
+If you want to include Iceberg in your Spark installation, add the [`iceberg-spark-runtime-3.2_2.12` Jar](spark-runtime-jar) to Spark's `jars` folder.
 {{< /hint >}}
 
 [spark-runtime-jar]: https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/{{% icebergVersion %}}/iceberg-spark-runtime-3.2_2.12-{{% icebergVersion %}}.jar

--- a/landing-page/config.toml
+++ b/landing-page/config.toml
@@ -4,7 +4,7 @@ title = "Apache Iceberg"
 
 [params]
   description = "The open table format for analytic datasets."
-  latestVersions.iceberg = "0.13.0"
+  latestVersions.iceberg = "0.13.1"
   docsBaseURL = ""
 
 [[params.social]]

--- a/landing-page/content/common/community/blogs.md
+++ b/landing-page/content/common/community/blogs.md
@@ -1,6 +1,5 @@
 ---
 url: blogs
-weight: 200
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/landing-page/content/common/community/contribute.md
+++ b/landing-page/content/common/community/contribute.md
@@ -1,0 +1,211 @@
+---
+url: contribute
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+# Contributing
+
+In this page, you will find some guidelines on contributing to Apache Iceberg. Please keep in mind that none of
+these are hard rules and they're meant as a collection of helpful suggestions to make contributing as seamless of an
+experience as possible.
+
+If you are thinking of contributing but first would like to discuss the change you wish to make, we welcome you to
+head over to the [Community](https://iceberg.apache.org/community/) page on the official Iceberg documentation site
+to find a number of ways to connect with the community, including slack and our mailing lists. Of course, always feel
+free to just open a [new issue](https://github.com/apache/iceberg/issues/new) in the GitHub repo.
+
+The Iceberg Project is hosted on GitHub at <https://github.com/apache/iceberg>.
+
+## Pull Request Process
+
+The Iceberg community prefers to receive contributions as [Github pull requests][github-pr-docs].
+
+[View open pull requests][iceberg-prs]
+
+
+[iceberg-prs]: https://github.com/apache/iceberg/pulls
+[github-pr-docs]: https://help.github.com/articles/about-pull-requests/
+
+* PRs are automatically labeled based on the content by our github-actions labeling action
+* It's helpful to include a prefix in the summary that provides context to PR reviewers, such as `Build:`, `Docs:`, `Spark:`, `Flink:`, `Core:`, `API:`
+* If a PR is related to an issue, adding `Closes #1234` in the PR description will automatically close the issue and helps keep the project clean
+* If a PR is posted for visibility and isn't necessarily ready for review or merging, be sure to convert the PR to a draft
+
+
+## Building the Project Locally
+
+Iceberg is built using Gradle with Java 8 or Java 11.
+
+* To invoke a build and run tests: `./gradlew build`
+* To skip tests: `./gradlew build -x test -x integrationTest`
+
+Iceberg table support is organized in library modules:
+
+* `iceberg-common` contains utility classes used in other modules
+* `iceberg-api` contains the public Iceberg API
+* `iceberg-core` contains implementations of the Iceberg API and support for Avro data files, **this is what processing engines should depend on**
+* `iceberg-parquet` is an optional module for working with tables backed by Parquet files
+* `iceberg-arrow` is an optional module for reading Parquet into Arrow memory
+* `iceberg-orc` is an optional module for working with tables backed by ORC files
+* `iceberg-hive-metastore` is an implementation of Iceberg tables backed by the Hive metastore Thrift client
+* `iceberg-data` is an optional module for working with tables directly from JVM applications
+
+This project Iceberg also has modules for adding Iceberg support to processing engines:
+
+* `iceberg-spark2` is an implementation of Spark's Datasource V2 API in 2.4 for Iceberg (use iceberg-spark-runtime for a shaded version)
+* `iceberg-spark3` is an implementation of Spark's Datasource V2 API in 3.0 for Iceberg (use iceberg-spark3-runtime for a shaded version)
+* `iceberg-flink` contains classes for integrating with Apache Flink (use iceberg-flink-runtime for a shaded version)
+* `iceberg-mr` contains an InputFormat and other classes for integrating with Apache Hive
+* `iceberg-pig` is an implementation of Pig's LoadFunc API for Iceberg
+
+## Iceberg Code Contribution Guidelines
+
+### Style
+
+For Java styling, check out the section
+[Setting up IDE and Code Style](https://iceberg.apache.org/community/#setting-up-ide-and-code-style) from the
+documentation site.
+
+For Python, please use the tox command `tox -e format` to apply autoformatting to the project.
+
+### Java style guidelines
+
+#### Line breaks
+
+Continuation indents are 2 indents (4 spaces) from the start of the previous line.
+
+Try to break long lines at the same semantic level to make code more readable.
+* Don't use the same level of indentation for arguments to different methods
+* Don't use the same level of indentation for arguments and chained methods
+
+```java
+  // BAD: hard to see arguments passed to the same method
+  doSomething(new ArgumentClass(1,
+      2),
+      3);
+
+  // GOOD: break lines at the same semantic level
+  doSomething(
+      new ArgumentClass(1, 2),
+      3);
+
+  // BAD: arguments and chained methods mixed
+  SomeObject myNewObject = SomeObject.builder(schema, partitionSpec,
+      sortOrder)
+      .withProperty("x", "1")
+      .build()
+
+  // GOOD: method calls at the same level, arguments indented
+  SomeObject myNewObject = SomeObject
+      .builder(schema, partitionSpec,
+          sortOrder)
+      .withProperty("x", "1")
+      .build()
+```
+
+#### Method naming
+
+1. Make method names as short as possible, while being clear. Omit needless words.
+2. Avoid `get` in method names, unless an object must be a Java bean.
+    * In most cases, replace `get` with a more specific verb that describes what is happening in the method, like `find` or `fetch`.
+    * If there isn't a more specific verb or the method is a getter, omit `get` because it isn't helpful to readers and makes method names longer.
+3. Where possible, use words and conjugations that form correct sentences in English when read
+    * For example, `Transform.preservesOrder()` reads correctly in an if statement: `if (transform.preservesOrder()) { ... }`
+
+#### Boolean arguments
+
+Avoid boolean arguments to methods that are not `private` to avoid confusing invocations like `sendMessage(false)`. It is better to create two methods with names and behavior, even if both are implemented by one internal method.
+
+```java
+  // prefer exposing suppressFailure in method names
+  public void sendMessageIgnoreFailure() {
+    sendMessageInternal(true);
+  }
+
+  public void sendMessage() {
+    sendMessageInternal(false);
+  }
+
+  private void sendMessageInternal(boolean suppressFailure) {
+    ...
+  }
+```
+
+When passing boolean arguments to existing or external methods, use inline comments to help the reader understand actions without an IDE.
+
+```java
+  // BAD: it is not clear what false controls
+  dropTable(identifier, false);
+
+  // GOOD: these uses of dropTable are clear to the reader
+  dropTable(identifier, true /* purge data */);
+  dropTable(identifier, purge);
+```
+
+#### Config naming
+
+1. Use `-` to link words in one concept
+    * For example, preferred convection `access-key-id` rather than `access.key.id`
+2. Use `.` to create a hierarchy of config groups
+    * For example, `s3` in `s3.access-key-id`, `s3.secret-access-key`
+
+## Website and Documentation Updates
+
+Currently, there is an [iceberg-docs](https://github.com/apache/iceberg-docs) repository
+which contains the HTML/CSS and other files needed for the [Iceberg website](https://iceberg.apache.org/).
+The [docs folder](https://github.com/apache/iceberg/tree/master/docs) in the Iceberg repository contains 
+the markdown content for the documentation site. All markdown changes should still be made
+to this repository.
+
+### Submitting Pull Requests
+
+Changes to the markdown contents should be submitted directly to this repository.
+
+Changes to the website appearance (e.g. HTML, CSS changes) should be submitted to the [iceberg-docs repository](https://github.com/apache/iceberg-docs) against the `main` branch.
+
+Changes to the documentation of old Iceberg versions should be submitted to the [iceberg-docs repository](https://github.com/apache/iceberg-docs) against the specific version branch.
+
+### Reporting Issues
+
+All issues related to the doc website should still be submitted to the [Iceberg repository](https://github.com/apache/iceberg).
+The GitHub Issues feature of the [iceberg-docs repository](https://github.com/apache/iceberg-docs) is disabled.
+
+### Running Locally
+
+Clone the [iceberg-docs](https://github.com/apache/iceberg-docs) repository to run the website locally:
+```shell
+git clone git@github.com:apache/iceberg-docs.git
+cd iceberg-docs
+```
+
+To start the landing page site locally, run:
+```shell
+cd landing-page && hugo serve
+```
+
+To start the documentation site locally, run:
+```shell
+cd docs && hugo serve
+```
+
+If you would like to see how the latest website looks based on the documentation in the Iceberg repository, you can copy docs to the iceberg-docs repository by:
+```shell
+rm -rf docs/content/docs
+rm -rf landing-page/content/common
+cp -r <path to iceberg repo>/docs/versioned docs/content/docs
+cp -r <path to iceberg repo>/docs/common landing-page/content/common
+```

--- a/landing-page/content/common/community/join.md
+++ b/landing-page/content/common/community/join.md
@@ -1,6 +1,5 @@
 ---
 url: community
-weight: 100
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more
@@ -25,19 +24,9 @@ Apache Iceberg tracks issues in GitHub and prefers to receive contributions as p
 
 Community discussions happen primarily on the dev mailing list, on apache-iceberg Slack workspace, and on specific GitHub issues.
 
+## Contribute
 
-## Contributing
-
-The Iceberg Project is hosted on Github at <https://github.com/apache/iceberg>.
-
-The Iceberg community prefers to receive contributions as [Github pull requests][github-pr-docs].
-
-* [View open pull requests][iceberg-prs]
-* [Learn about pull requests][github-pr-docs]
-
-[iceberg-prs]: https://github.com/apache/iceberg/pulls
-[github-pr-docs]: https://help.github.com/articles/about-pull-requests/
-
+See [Contributing](../../../contribute) for more details on how to contribute to Iceberg.
 
 ## Issues
 

--- a/landing-page/content/common/community/talks.md
+++ b/landing-page/content/common/community/talks.md
@@ -1,6 +1,5 @@
 ---
 url: talks
-weight: 300
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/landing-page/content/common/project/how-to-release.md
+++ b/landing-page/content/common/project/how-to-release.md
@@ -60,6 +60,11 @@ To use `gpg` instead of `gpg2`, also set `signing.gnupg.executable=gpg`
 
 For more information, see the Gradle [signing documentation](https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials).
 
+### Apache repository
+
+The release should be executed against `https://github.com/apache/iceberg.git` instead of any fork.
+Set it as remote with name `apache` for release if it is not already set up.
+
 ## Creating a release candidate
 
 ### Build the source release
@@ -254,4 +259,70 @@ This release can be downloaded from: https://www.apache.org/dyn/closer.cgi/icebe
 Java artifacts are available from Maven Central.
 
 Thanks to everyone for contributing!
+```
+
+### Documentation Release
+
+Documentation needs to be updated as a part of Iceberg release after a release candidate is passed.
+The commands described below assume the `iceberg-docs` repository and `iceberg` repository are in the same parent directory locally, 
+and the release manager is executing commands in the `iceberg` repository.
+Adjust the commands accordingly if it is not the case.
+
+#### iceberg repository preparations
+
+A PR needs to be published in `iceberg` repository with the following changes:
+1. Mark the current latest release notes to past releases
+2. Update the latest artifact links in the release notes page
+3. Add release notes for the new release version
+2. Create new folder called `docs/versioned/releases/<VERSION NUMBER>` with a `_index.md` file. See the existing folders under `docs/versioned/releases` for more details.
+
+#### iceberg-docs repository preparations
+
+A PR needs to be published in `iceberg-docs` repository with the following changes:
+1. Update variable `latestVersions.iceberg` to the new release version in `landing-page/config.toml`
+2. Update variable `latestVersions.iceberg` to the new release version in `docs/config.toml`
+
+#### Documentation update
+
+To start the release process, run the following steps in the `iceberg-docs` repository to copy docs over:
+
+```shell
+rm -rf ../iceberg-docs/docs/content/docs
+rm -rf ../iceberg-docs/landing-page/content/common
+cp -r docs/versioned ../iceberg-docs/docs/content/docs
+cp -r docs/common ../iceberg-docs/landing-page/content/common
+```
+
+The resulted changes in `iceberg-docs` should be approved in a separate PR.
+
+#### Javadoc update
+
+In the `iceberg` repository, generate the javadoc for your release and copy it to the `javadoc` folder in `iceberg-docs` repo:
+```shell
+./gradlew refreshJavadoc
+rm -rf ../iceberg-docs/javadoc
+cp site/docs/javadoc/<VERSION NUMBER> ../iceberg-docs/javadoc
+```
+
+This resulted changes in `iceberg-docs` should be approved in a separate PR.
+
+#### Cut a new version branch
+
+Once completed, go to the `iceberg-docs` repository to cut a new branch using the version number as the branch name.
+For example, to cut a new versioned doc for release `0.13.0`:
+
+```shell
+git checkout -b 0.13.0
+git push --set-upstream apache 0.13.0
+```
+
+#### Update the latest branch
+
+The last step is to point the `latest` branch to the latest version.
+Because `main` is currently the same as the version branch, simply rebase `latest` branch against `main`:
+
+```shell
+git checkout latest
+git rebase main
+git push apache latest
 ```

--- a/landing-page/content/common/project/multi-engine-support.md
+++ b/landing-page/content/common/project/multi-engine-support.md
@@ -40,7 +40,7 @@ For Hive, Hive 2 uses the `iceberg-mr` package for Iceberg integration, and Hive
 
 ### Runtime Jar
 
-Iceberg provides a runtime connector Jar for each supported version of Spark, Flink and Hive.
+Iceberg provides a runtime connector jar for each supported version of Spark, Flink and Hive.
 When using Iceberg with these engines, the runtime jar is the only addition to the classpath needed in addition to vendor dependencies.
 For example, to use Iceberg with Spark 3.2 and AWS integrations, `iceberg-spark-runtime-3.2_2.12` and AWS SDK dependencies are needed for the Spark installation.
 
@@ -61,32 +61,36 @@ Each engine version undergoes the following lifecycle stages:
 
 ### Apache Spark
 
-Note that Spark 2.4 and 3.0 artifact names do not comply to the naming convention of later versions for backwards compatibility.
+| Version    | Lifecycle Stage    | Initial Iceberg Support | Latest Iceberg Support | Latest Runtime Jar |
+| ---------- | ------------------ | ----------------------- | ---------------------- | ------------------ |
+| 2.4        | Deprecated         | 0.7.0-incubating        | {{% icebergVersion %}} | [iceberg-spark-runtime](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime/{{% icebergVersion %}}/iceberg-spark-runtime-{{% icebergVersion %}}.jar) |
+| 3.0        | Maintained         | 0.9.0                   | {{% icebergVersion %}} | [iceberg-spark3-runtime](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark3-runtime/{{% icebergVersion %}}/iceberg-spark3-runtime-{{% icebergVersion %}}.jar) [1] |
+| 3.1        | Maintained         | 0.12.0                  | {{% icebergVersion %}} | [iceberg-spark-runtime-3.1_2.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.1_2.12/{{% icebergVersion %}}/iceberg-spark-runtime-3.1_2.12-{{% icebergVersion %}}.jar) [2] |
+| 3.2        | Maintained         | 0.13.0                  | {{% icebergVersion %}} | [iceberg-spark-runtime-3.2_2.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/{{% icebergVersion %}}/iceberg-spark-runtime-3.2_2.12-{{% icebergVersion %}}.jar) |
 
-| Version    | Lifecycle Stage    | Runtime Artifact |
-| ---------- | ------------------ | ---------------- |
-| 2.4        | Deprecated         | [iceberg-spark-runtime](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime/{{% icebergVersion %}}/iceberg-spark-runtime-{{% icebergVersion %}}.jar) |
-| 3.0        | Maintained         | [iceberg-spark3-runtime](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark3-runtime/{{% icebergVersion %}}/iceberg-spark3-runtime-{{% icebergVersion %}}.jar) |
-| 3.1        | Maintained         | [iceberg-spark-runtime-3.1_2.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.1_2.12/{{% icebergVersion %}}/iceberg-spark-runtime-3.1_2.12-{{% icebergVersion %}}.jar) |
-| 3.2        | Maintained         | [iceberg-spark-runtime-3.2_2.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/{{% icebergVersion %}}/iceberg-spark-runtime-3.2_2.12-{{% icebergVersion %}}.jar) |
+* [1] Spark 2.4 and 3.0 jar names do not follow the naming convention of newer versions for backwards compatibility
+* [2] Spark 3.1 shares the same runtime jar `iceberg-spark3-runtime` with Spark 3.0 before Iceberg 0.13.0
 
 ### Apache Flink
 
 Based on the guideline of the Flink community, only the latest 2 minor versions are actively maintained.
 Users should continuously upgrade their Flink version to stay up-to-date.
 
-| Version    | Lifecycle Stage   | Runtime Artifact |
-| ---------- | ----------------- | ---------------- |
-| 1.12       | Deprecated        | [iceberg-flink-runtime-1.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.12/{{% icebergVersion %}}/iceberg-flink-runtime-1.12-{{% icebergVersion %}}.jar) |
-| 1.13       | Maintained        | [iceberg-flink-runtime-1.13](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.13/{{% icebergVersion %}}/iceberg-flink-runtime-1.13-{{% icebergVersion %}}.jar) |
-| 1.14       | Maintained        | [iceberg-flink-runtime-1.14](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.14/{{% icebergVersion %}}/iceberg-flink-runtime-1.14-{{% icebergVersion %}}.jar) |
+| Version    | Lifecycle Stage   | Initial Iceberg Support | Latest Iceberg Support | Latest Runtime Jar |
+| ---------- | ----------------- | ----------------------- | ---------------------- | ------------------ |
+| 1.11       | End of Life       | 0.9.0                   | 0.12.1                 | [iceberg-flink-runtime](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime/0.12.1/iceberg-flink-runtime-0.12.1.jar) |
+| 1.12       | Deprecated        | 0.12.0                  | {{% icebergVersion %}} | [iceberg-flink-runtime-1.12](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.12/{{% icebergVersion %}}/iceberg-flink-runtime-1.12-{{% icebergVersion %}}.jar) [3] |
+| 1.13       | Maintained        | 0.13.0                  | {{% icebergVersion %}} | [iceberg-flink-runtime-1.13](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.13/{{% icebergVersion %}}/iceberg-flink-runtime-1.13-{{% icebergVersion %}}.jar) |
+| 1.14       | Maintained        | 0.13.0                  | {{% icebergVersion %}} | [iceberg-flink-runtime-1.14](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.14/{{% icebergVersion %}}/iceberg-flink-runtime-1.14-{{% icebergVersion %}}.jar) |
+
+* [3] Flink 1.12 shares the same runtime jar `iceberg-flink-runtime` with Flink 1.11 before Iceberg 0.13.0
 
 ### Apache Hive
 
-| Version        | Recommended minor version | Lifecycle Stage   | Runtime Artifact |
-| -------------- | ------------------------- | ----------------- | ---------------- |
-| 2              | 2.3.8                     | Maintained        | [iceberg-hive-runtime](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-hive-runtime/{{% icebergVersion %}}/iceberg-hive-runtime-{{% icebergVersion %}}.jar) |
-| 3              | 3.1.2                     | Maintained        | [iceberg-hive-runtime](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-hive-runtime/{{% icebergVersion %}}/iceberg-hive-runtime-{{% icebergVersion %}}.jar) |
+| Version        | Recommended minor version | Lifecycle Stage   | Initial Iceberg Support | Latest Iceberg Support | Latest Runtime Jar |
+| -------------- | ------------------------- | ----------------- | ----------------------- | ---------------------- | ------------------ |
+| 2              | 2.3.8                     | Maintained        | 0.8.0-incubating        | {{% icebergVersion %}} | [iceberg-hive-runtime](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-hive-runtime/{{% icebergVersion %}}/iceberg-hive-runtime-{{% icebergVersion %}}.jar) |
+| 3              | 3.1.2                     | Maintained        | 0.10.0                  | {{% icebergVersion %}} | [iceberg-hive-runtime](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-hive-runtime/{{% icebergVersion %}}/iceberg-hive-runtime-{{% icebergVersion %}}.jar) |
 
 ## Developer Guide
 

--- a/landing-page/content/common/releases/release-notes.md
+++ b/landing-page/content/common/releases/release-notes.md
@@ -66,9 +66,38 @@ To add a dependency on Iceberg in Maven, add the following to your `pom.xml`:
 </dependencies>
 ```
 
-## 0.13.0 Release Notes
+## 0.13.1 Release Notes
+
+Apache Iceberg 0.13.1 was released on February 14th, 2022.
+
+**Important bug fixes:**
+
+* **Spark**
+  * [\#4023](https://github.com/apache/iceberg/pull/4023) fixes predicate pushdown in row-level operations for merge conditions in Spark 3.2. 
+  Prior to the fix, filters would not be extracted and targeted merge conditions were not pushed down leading to degraded performance
+  for these targeted merge operations.
+  * [\#4024](https://github.com/apache/iceberg/pull/4024) fixes table creation in the root namespace of a Hadoop Catalog.
+
+* **Flink**
+  * [\#3986](https://github.com/apache/iceberg/pull/3986) fixes manifest location collisions when there are multiple committers
+  in the same Flink job.
+
+## Past releases
+
+### 0.13.0 Release Notes
 
 Apache Iceberg 0.13.0 was released on February 4th, 2022.
+
+* Git tag: [0.13.0](https://github.com/apache/iceberg/releases/tag/apache-iceberg-0.13.0)
+* [0.13.0 source tar.gz](https://www.apache.org/dyn/closer.cgi/iceberg/apache-iceberg-0.13.0/apache-iceberg-0.13.0.tar.gz) -- [signature](https://downloads.apache.org/iceberg/apache-iceberg-0.13.0/apache-iceberg-0.13.0.tar.gz.asc) -- [sha512](https://downloads.apache.org/iceberg/apache-iceberg-0.13.0/apache-iceberg-0.13.0.tar.gz.sha512)
+* [0.13.0 Spark 3.2 runtime Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/0.13.0/iceberg-spark-runtime-3.2_2.12-0.13.0.jar)
+* [0.13.0 Spark 3.1 runtime Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.1_2.12/0.13.0/iceberg-spark-runtime-3.1_2.12-0.13.0.jar)
+* [0.13.0 Spark 3.0 runtime Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark3-runtime/0.13.0/iceberg-spark3-runtime-0.13.0.jar)
+* [0.13.0 Spark 2.4 runtime Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime/0.13.0/iceberg-spark-runtime-0.13.0.jar)
+* [0.13.0 Flink 1.14 runtime Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.14/0.13.0/iceberg-flink-runtime-1.14-0.13.0.jar)
+* [0.13.0 Flink 1.13 runtime Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.13/0.13.0/iceberg-flink-runtime-1.13-0.13.0.jar)
+* [0.13.0 Flink 1.12 runtime Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-flink-runtime-1.12/0.13.0/iceberg-flink-runtime-1.12-0.13.0.jar)
+* [0.13.0 Hive runtime Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-hive-runtime/0.13.0/iceberg-hive-runtime-0.13.0.jar)
 
 **High-level features:**
 
@@ -130,8 +159,6 @@ Apache Iceberg 0.13.0 was released on February 4th, 2022.
 **Other notable changes:**
 
 * The community has finalized the long-term strategy of Spark, Flink and Hive support. See [Multi-Engine Support](../multi-engine-support) page for more details.
-
-## Past releases
 
 ### 0.12.1
 


### PR DESCRIPTION
In this change we are copying over the new markdowns and doc changes from the Iceberg repo. Validated by running hugo serve for the landing page/docs.