### PR TITLE
Update Nessie version to 0.20.0 in the latest docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -7,6 +7,6 @@ theme= "hugo-book"
   BookTheme = 'auto'
   BookLogo = "img/iceberg-logo-icon.png"
   versions.iceberg = "" # This is populated by the github deploy workflow and is equal to the branch name
-  versions.nessie = "0.18.0"
+  versions.nessie = "0.19.0"
   latestVersions.iceberg = "0.13.1"  # This is used for the version badge on the "latest" site version
   BookSection='docs' # This determines which directory will inform the left navigation menu

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -7,6 +7,6 @@ theme= "hugo-book"
   BookTheme = 'auto'
   BookLogo = "img/iceberg-logo-icon.png"
   versions.iceberg = "" # This is populated by the github deploy workflow and is equal to the branch name
-  versions.nessie = "0.19.0"
+  versions.nessie = "0.20.0"
   latestVersions.iceberg = "0.13.1"  # This is used for the version badge on the "latest" site version
   BookSection='docs' # This determines which directory will inform the left navigation menu


### PR DESCRIPTION
In the Iceberg repo, Nessie is updated to 0.20.0 in https://github.com/apache/iceberg/pull/4055
Hence updating the site docs config.