### PR TITLE
Anchor tags and Table of Contents

### DIFF
--- a/landing-page/content/common/spec.md
+++ b/landing-page/content/common/spec.md
@@ -1,5 +1,6 @@
 ---
 url: spec
+toc: true
 aliases:
     - "spec"
 ---
@@ -30,13 +31,13 @@ Versions 1 and 2 of the Iceberg spec are complete and adopted by the community.
 
 The format version number is incremented when new features are added that will break forward-compatibility---that is, when older readers would not read newer table features correctly. Tables may continue to be written with an older version of the spec to ensure compatibility by not using features that are not yet implemented by processing engines.
 
-#### Version 1: Analytic Data Tables
+### Version 1: Analytic Data Tables
 
 Version 1 of the Iceberg spec defines how to manage large analytic tables using immutable file formats: Parquet, Avro, and ORC.
 
 All version 1 data and metadata files are valid after upgrading a table to version 2. [Appendix E](spec/#version-2) documents how to default version 2 fields when reading version 1 metadata.
 
-#### Version 2: Row-level Deletes
+### Version 2: Row-level Deletes
 
 Version 2 of the Iceberg spec adds row-level updates and deletes for analytic tables with immutable files.
 
@@ -67,7 +68,7 @@ Data files in snapshots are tracked by one or more manifest files that contain a
 
 The manifests that make up a snapshot are stored in a manifest list file. Each manifest list stores metadata about manifests, including partition stats and data file counts. These stats are used to avoid reading manifests that are not required for an operation.
 
-#### Optimistic Concurrency
+### Optimistic Concurrency
 
 An atomic swap of one table metadata file for another provides the basis for serializable isolation. Readers use the snapshot that was current when they load the table metadata and are not affected by changes until they refresh and pick up a new metadata location.
 
@@ -77,7 +78,7 @@ If the snapshot on which an update is based is no longer current, the writer mus
 
 The conditions required by a write to successfully commit determines the isolation level. Writers can select what to validate and can make different isolation guarantees.
 
-#### Sequence Numbers
+### Sequence Numbers
 
 The relative age of data and delete files relies on a sequence number that is assigned to every successful commit. When a snapshot is created for a commit, it is optimistically assigned the next sequence number, and it is written into the snapshot's metadata. If the commit fails and must be retried, the sequence number is reassigned and written into new snapshot metadata.
 
@@ -86,7 +87,7 @@ All manifests, data files, and delete files created for a snapshot inherit the s
 Inheriting the sequence number from manifest metadata allows writing a new manifest once and reusing it in commit retries. To change a sequence number for a retry, only the manifest list must be rewritten -- which would be rewritten anyway with the latest set of manifests.
 
 
-#### Row-level Deletes
+### Row-level Deletes
 
 Row-level deletes are stored in delete files.
 
@@ -98,7 +99,7 @@ There are two ways to encode a row-level delete:
 Like data files, delete files are tracked by partition. In general, a delete file must be applied to older data files with the same partition; see [Scan Planning](spec/#scan-planning) for details. Column metrics can be used to determine whether a delete file's rows overlap the contents of a data file or a scan range.
 
 
-#### File System Operations
+### File System Operations
 
 Iceberg only requires that file systems support the following operations:
 
@@ -115,7 +116,7 @@ Tables do not require rename, except for tables that use atomic rename to implem
 
 ## Specification
 
-#### Terms
+### Terms
 
 * **Schema** -- Names and types of fields in a table.
 * **Partition spec** -- A definition of how partition values are derived from data fields.
@@ -125,7 +126,7 @@ Tables do not require rename, except for tables that use atomic rename to implem
 * **Data file** -- A file that contains rows of a table.
 * **Delete file** -- A file that encodes rows of a table that are deleted by position or data values.
 
-#### Writer requirements
+### Writer requirements
 
 Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata files to a table with the given version.
 

--- a/landing-page/layouts/_default/single.html
+++ b/landing-page/layouts/_default/single.html
@@ -3,6 +3,7 @@
     <link href="{{ .Site.BaseURL }}/css/markdown.css" rel="stylesheet">
     <link href="{{ .Site.BaseURL }}/css/katex.min.css" rel="stylesheet">
     <script>
+        // This automatically adds an anchor tag for every h1, h2, h3, and h4 element on the page
         function addAnchor(element) {
             element.insertAdjacentHTML('beforeend', `<a href="#${element.id}" class="anchortag" ariaLabel="Anchor"> 🔗 </a>` )
         }

--- a/landing-page/layouts/_default/single.html
+++ b/landing-page/layouts/_default/single.html
@@ -16,8 +16,11 @@
 </head>
 {{ partial "header.html" . }}
 <body dir="{{ .Site.Language.LanguageDirection | default " ltr" }}">
-    <div class="markdown-body">
-        {{- .Content -}}
+    <div class="grid-container">
+        {{ partial "toc.html" . }}
+        <div class="markdown-body">
+            {{- .Content -}}
+        </div>
     </div>
 </body>
 

--- a/landing-page/layouts/_default/single.html
+++ b/landing-page/layouts/_default/single.html
@@ -2,6 +2,17 @@
 <head>
     <link href="{{ .Site.BaseURL }}/css/markdown.css" rel="stylesheet">
     <link href="{{ .Site.BaseURL }}/css/katex.min.css" rel="stylesheet">
+    <script>
+        function addAnchor(element) {
+            element.insertAdjacentHTML('beforeend', `<a href="#${element.id}" class="anchortag" ariaLabel="Anchor"> 🔗 </a>` )
+        }
+        document.addEventListener('DOMContentLoaded', function () {
+            var headers = document.querySelectorAll('h1[id], h2[id], h3[id], h4[id]')
+            if (headers) {
+                headers.forEach(addAnchor)
+            }
+        });
+    </script>
 </head>
 {{ partial "header.html" . }}
 <body dir="{{ .Site.Language.LanguageDirection | default " ltr" }}">

--- a/landing-page/layouts/partials/head.html
+++ b/landing-page/layouts/partials/head.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <base href="{{ .Site.BaseURL }}">
     <title>{{ .Title }}</title>
 
     

--- a/landing-page/layouts/partials/header.html
+++ b/landing-page/layouts/partials/header.html
@@ -9,7 +9,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="page-scroll navbar-brand" href="#intro"><img class="top-navbar-logo" src="{{ .Site.BaseURL }}/img/iceberg-logo-icon.png"/> {{ .Site.Title }}</a>
+            <a class="page-scroll navbar-brand" href="{{ .Site.BaseURL }}"><img class="top-navbar-logo" src="{{ .Site.BaseURL }}/img/iceberg-logo-icon.png"/> {{ .Site.Title }}</a>
             
         </div>
         <!-- Collect the nav links, forms, and other content for toggling -->

--- a/landing-page/layouts/partials/toc.html
+++ b/landing-page/layouts/partials/toc.html
@@ -1,0 +1,7 @@
+{{ if (.Params.toc) }}
+<div id="toc" class="markdown-body">
+    <div id="full">
+        {{.TableOfContents}}
+    </div>
+</div>
+{{ end }}

--- a/landing-page/static/css/landing-page.css
+++ b/landing-page/static/css/landing-page.css
@@ -9,6 +9,8 @@ html {
     width: 100%;
     height: 100%;
     font-size: 20px;    
+    scroll-padding-top: 3rem;
+    scroll-behavior: smooth;
 }
 
 body,
@@ -225,3 +227,11 @@ a.page-scroll {
 .termynal-container {
     padding-top: 3rem;
 }
+
+/* Anchor tags for headers */
+.anchortag { font-size: 80%; visibility: hidden;}
+
+h1:hover a { visibility: visible}
+h2:hover a { visibility: visible}
+h3:hover a { visibility: visible}
+h4:hover a { visibility: visible}

--- a/landing-page/static/css/landing-page.css
+++ b/landing-page/static/css/landing-page.css
@@ -264,5 +264,5 @@ h4:hover a { visibility: visible}
 }
 
 @media screen and (min-width: 401px) and (max-width: 1280px) {
-    #toc { display: none; }   /* hide it elsewhere */
+    #toc { display: none; }  /* Hide the TOC if the page is less than 1280px */
   }

--- a/landing-page/static/css/landing-page.css
+++ b/landing-page/static/css/landing-page.css
@@ -240,7 +240,7 @@ h4:hover a { visibility: visible}
 .grid-container {
     display: grid;
     grid-template-columns: 5fr 1fr;
-    grid-gap: 10px;
+    grid-gap: 1rem;
 }
 
 
@@ -254,8 +254,7 @@ h4:hover a { visibility: visible}
     font-size: 0.6rem;
     width: 20rem;
     min-width: 0;
-    padding: 30px;
-    padding-right: 50px;
+    padding: 2rem;
     margin-top: 2rem;
     list-style-type: none;
 }

--- a/landing-page/static/css/landing-page.css
+++ b/landing-page/static/css/landing-page.css
@@ -235,3 +235,35 @@ h1:hover a { visibility: visible}
 h2:hover a { visibility: visible}
 h3:hover a { visibility: visible}
 h4:hover a { visibility: visible}
+
+/* Fixed table of contents */
+.grid-container {
+    display: grid;
+    grid-template-columns: 5fr 1fr;
+    grid-gap: 10px;
+}
+
+
+#toc {
+    position: fixed;
+    right: 0;
+    top: 0;
+    background-color:#FFF;
+    display: block;
+    flex: 0 0 20rem;
+    font-size: 0.6rem;
+    width: 20rem;
+    min-width: 0;
+    padding: 30px;
+    padding-right: 50px;
+    margin-top: 2rem;
+    list-style-type: none;
+}
+
+#toc ul {
+    list-style: none;
+}
+
+@media screen and (min-width: 401px) and (max-width: 1280px) {
+    #toc { display: none; }   /* hide it elsewhere */
+  }

--- a/landing-page/static/css/markdown.css
+++ b/landing-page/static/css/markdown.css
@@ -226,7 +226,7 @@ body {
 }
 
 .markdown-body a:hover {
-  text-decoration: underline
+  text-decoration: none
 }
 
 .markdown-body hr::before {


### PR DESCRIPTION
This adds anchor tag links that reveal as 🔗 on hover and also allows turning on a right-fixed table of contents using `toc: true` in the front matter of a common page. This PR only turns the table of content on for `/spec` but if there are other pages that should have a TOC (Releases? Community?) I can update this PR.

<img width="1776" alt="Screen Shot 2022-03-14 at 5 22 16 PM" src="https://user-images.githubusercontent.com/43911210/158282172-d277868b-83c4-429b-8e73-a1f756bfb74b.png">


Example of anchor tag hover, 🔗 is linked to _/spec/#format-versioning_
<img width="1787" alt="Screen Shot 2022-03-14 at 5 22 31 PM" src="https://user-images.githubusercontent.com/43911210/158282177-5d953585-8940-4855-901c-653e3d28b0bf.png">

