### PR TITLE
Remove min-width for hiding table of content

### DIFF
--- a/landing-page/static/css/landing-page.css
+++ b/landing-page/static/css/landing-page.css
@@ -263,6 +263,6 @@ h4:hover a { visibility: visible}
     list-style: none;
 }
 
-@media screen and (min-width: 401px) and (max-width: 1280px) {
+@media screen and (max-width: 1280px) {
     #toc { display: none; }  /* Hide the TOC if the page is less than 1280px */
   }


### PR DESCRIPTION
Small tweak that removes the `min-width` for hiding the table of content. Since there's no space for the fixed table of content on very small screens like mobile devices, this will make the table of content only show when the screen width is greater than 1280px.

cc: @rdblue 