### PR TITLE
Add Spark 3.1 and 3.2 to feature chart

### DIFF
--- a/docs/content/docs/spark/spark-queries.md
+++ b/docs/content/docs/spark/spark-queries.md
@@ -27,15 +27,15 @@ To use Iceberg in Spark, first configure [Spark catalogs](../spark-configuration
 
 Iceberg uses Apache Spark's DataSourceV2 API for data source and catalog implementations. Spark DSv2 is an evolving API with different levels of support in Spark versions:
 
-| Feature support                                  | Spark 3.0| Spark 2.4  | Notes                                          |
-|--------------------------------------------------|----------|------------|------------------------------------------------|
-| [`SELECT`](#querying-with-sql)                   | ✔️        |            |                                                |
-| [DataFrame reads](#querying-with-dataframes)     | ✔️        | ✔️          |                                                |
-| [Metadata table `SELECT`](#inspecting-tables)    | ✔️        |            |                                                |
-| [History metadata table](#history)               | ✔️        | ✔️          |                                                |
-| [Snapshots metadata table](#snapshots)           | ✔️        | ✔️          |                                                |
-| [Files metadata table](#files)                   | ✔️        | ✔️          |                                                |
-| [Manifests metadata table](#manifests)           | ✔️        | ✔️          |                                                |
+| Feature support                                  | Spark 3.2| Spark 3.1| Spark 3.0| Spark 2.4  | Notes                                          |
+|--------------------------------------------------|----------|----------|----------|------------|------------------------------------------------|
+| [`SELECT`](#querying-with-sql)                   | ✔️        | ✔️        | ✔️        |            |                                                |
+| [DataFrame reads](#querying-with-dataframes)     | ✔️        | ✔️        | ✔️        | ✔️          |                                                |
+| [Metadata table `SELECT`](#inspecting-tables)    | ✔️        | ✔️        | ✔️        |            |                                                |
+| [History metadata table](#history)               | ✔️        | ✔️        | ✔️        | ✔️          |                                                |
+| [Snapshots metadata table](#snapshots)           | ✔️        | ✔️        | ✔️        | ✔️          |                                                |
+| [Files metadata table](#files)                   | ✔️        | ✔️        | ✔️        | ✔️          |                                                |
+| [Manifests metadata table](#manifests)           | ✔️        | ✔️        | ✔️        | ✔️          |                                                |
 
 
 ## Querying with SQL


### PR DESCRIPTION
This adds Spark 3.1 and 3.2 to the feature matrix. Let me know which additional features need to be listed for 3.1 and 3.2 (i.e. `MERGE INTO`) and I'll update this PR.

<img width="1413" alt="Screen Shot 2022-03-15 at 3 36 51 PM" src="https://user-images.githubusercontent.com/43911210/158483790-85855039-2b55-475b-ac2b-82232e6f65a1.png">

cc: @rdblue