### PR TITLE
Add Spark 3.1 and 3.2 to feature chart (#65)

### DIFF
--- a/docs/content/docs/spark/spark-queries.md
+++ b/docs/content/docs/spark/spark-queries.md
@@ -27,15 +27,15 @@ To use Iceberg in Spark, first configure [Spark catalogs](../spark-configuration
 
 Iceberg uses Apache Spark's DataSourceV2 API for data source and catalog implementations. Spark DSv2 is an evolving API with different levels of support in Spark versions:
 
-| Feature support                                  | Spark 3.0| Spark 2.4  | Notes                                          |
-|--------------------------------------------------|----------|------------|------------------------------------------------|
-| [`SELECT`](#querying-with-sql)                   | ✔️        |            |                                                |
-| [DataFrame reads](#querying-with-dataframes)     | ✔️        | ✔️          |                                                |
-| [Metadata table `SELECT`](#inspecting-tables)    | ✔️        |            |                                                |
-| [History metadata table](#history)               | ✔️        | ✔️          |                                                |
-| [Snapshots metadata table](#snapshots)           | ✔️        | ✔️          |                                                |
-| [Files metadata table](#files)                   | ✔️        | ✔️          |                                                |
-| [Manifests metadata table](#manifests)           | ✔️        | ✔️          |                                                |
+| Feature support                                  | Spark 3.2| Spark 3.1| Spark 3.0| Spark 2.4  | Notes                                          |
+|--------------------------------------------------|----------|----------|----------|------------|------------------------------------------------|
+| [`SELECT`](#querying-with-sql)                   | ✔️        | ✔️        | ✔️        |            |                                                |
+| [DataFrame reads](#querying-with-dataframes)     | ✔️        | ✔️        | ✔️        | ✔️          |                                                |
+| [Metadata table `SELECT`](#inspecting-tables)    | ✔️        | ✔️        | ✔️        |            |                                                |
+| [History metadata table](#history)               | ✔️        | ✔️        | ✔️        | ✔️          |                                                |
+| [Snapshots metadata table](#snapshots)           | ✔️        | ✔️        | ✔️        | ✔️          |                                                |
+| [Files metadata table](#files)                   | ✔️        | ✔️        | ✔️        | ✔️          |                                                |
+| [Manifests metadata table](#manifests)           | ✔️        | ✔️        | ✔️        | ✔️          |                                                |
 
 
 ## Querying with SQL


### PR DESCRIPTION
This moves this recent hotfix for 0.13.1 to the latest branch.

cc: @rdblue 