### PR TITLE
Add hint boxes and codetabs to landing-page

### DIFF
--- a/landing-page/config.toml
+++ b/landing-page/config.toml
@@ -19,3 +19,6 @@ title = "Apache Iceberg"
   title = "slack"
   icon = "slack"
   url = "https://join.slack.com/t/apache-iceberg/shared_invite/zt-tlv0zjz6-jGJEkHfb1~heMCJA3Uycrg"  
+
+[markup.goldmark.renderer]
+unsafe= true

--- a/landing-page/layouts/shortcodes/addtab.html
+++ b/landing-page/layouts/shortcodes/addtab.html
@@ -1,0 +1,2 @@
+<input id="{{ .Get 0 }}" type="radio" name="tabs" checked>
+<label for="{{ .Get 0 }}">{{ .Get 0 }}</label>

--- a/landing-page/layouts/shortcodes/codetabs.html
+++ b/landing-page/layouts/shortcodes/codetabs.html
@@ -1,0 +1,1 @@
+<div id="codetabs">{{ .Inner }}</div>

--- a/landing-page/layouts/shortcodes/hint.html
+++ b/landing-page/layouts/shortcodes/hint.html
@@ -1,0 +1,3 @@
+<div class="{{ .Get 0 }}">
+    {{ .Inner | .Page.RenderString }}
+</div>

--- a/landing-page/layouts/shortcodes/tabcontent.html
+++ b/landing-page/layouts/shortcodes/tabcontent.html
@@ -1,0 +1,3 @@
+<section id="{{ .Get 0 }}">
+      {{ .Inner }}
+</section>

--- a/landing-page/static/css/landing-page.css
+++ b/landing-page/static/css/landing-page.css
@@ -266,3 +266,85 @@ h4:hover a { visibility: visible}
 @media screen and (max-width: 1280px) {
     #toc { display: none; }  /* Hide the TOC if the page is less than 1280px */
   }
+
+/* Style for the hint shortcode */
+.info, .success, .warning, .error {
+    margin: 10px 0px;
+    padding:12px;
+ 
+}
+.info {
+    color: #00529B;
+    background-color: #BDE5F8;
+}
+.success {
+    color: #4F8A10;
+    background-color: #DFF2BF;
+}
+.warning {
+    color: #9F6000;
+    background-color: #FEEFB3;
+}
+.error {
+    color: #D8000C;
+    background-color: #FFD2D2;
+}
+
+/* Style the codetab shortcode */
+  #codetabs h1 {
+    padding: 50px 0;
+    font-weight: 400;
+    text-align: center;
+  }
+  
+  #codetabs p {
+    margin: 0 0 20px;
+    line-height: 1.5;
+  }
+  
+  #codetabs main {
+    min-width: 320px;
+    max-width: 800px;
+    padding: 50px;
+    margin: 0 auto;
+    background: #fff;
+  }
+  
+  #codetabs section {
+    display: none;
+    padding: 20px 0 0;
+    border-top: 1px solid #ddd;
+  }
+  
+  #codetabs input {
+    display: none;
+  }
+  
+  #codetabs label {
+    display: inline-block;
+    margin: 0 0 -1px;
+    padding: 15px 25px;
+    font-weight: 600;
+    text-align: center;
+    color: #bbb;
+    border: 1px solid transparent;
+  }
+  
+  #codetabs label:hover {
+    color: #000;
+    cursor: pointer;
+  }
+  
+  #codetabs input:checked + label {
+    color: #000;
+    border: 1px solid #ddd;
+    border-top: 2px solid orange;
+    border-bottom: 1px solid #fff;
+  }
+  
+  #codetabs #Python:checked ~ #Python,
+  #codetabs #Java:checked ~ #Java,
+  #codetabs #Scala:checked ~ #Scala,
+  #codetabs #tab4:checked ~ #content4 {
+    display: block;
+  }


### PR DESCRIPTION
This adds some shortcodes to the landing-page theme that allows us to include hint-boxes and codetabs (code blocks in a tabbed container for multiple languages). Here's an example of what this looks like:
![hint_boxes_and_codetabs](https://user-images.githubusercontent.com/43911210/164126829-e2cf290b-b9b7-44d4-bc73-dcb10d7125db.gif)



Here's the code directly in the markdown file that utilized the shortcodes to create what's seen above.
~~~
# Example

## Hint Boxes

{{< hint info >}}
This is an info hint box
{{< /hint >}}

{{< hint success >}}
This is a success hint box
{{< /hint >}}

{{< hint warning >}}
This is a warning hint box
{{< /hint >}}

{{< hint error >}}
This is an error hint box
{{< /hint >}}

## Codetabs

{{% codetabs %}}

{{% addtab "Python" %}}
{{% addtab "Java" %}}
{{% addtab "Scala" %}}

{{% tabcontent "Python" %}}
```py
print("Hello, World")
```
{{% /tabcontent %}}

{{% tabcontent "Java" %}}
```java
public class HelloWorld {
    public static void main(String[] args) {
        System.out.println("Hello, World");
    }
}
```
{{% /tabcontent %}}

{{% tabcontent "Scala" %}}
```scala
object HelloWorld extends App {
    println("Hello, World")
}
```
{{% /tabcontent %}}

{{% /codetabs %}}
~~~