### PR TITLE
Docs:Move searchbar to the top of the page and Widen the Search Preview Window(fix #4095)

### DIFF
--- a/docs/assets/_custom.scss
+++ b/docs/assets/_custom.scss
@@ -45,6 +45,7 @@ li.navigation-icon-pad {
 
 #book-search-results {
   position: absolute;
+  top: 110px;
 }
 
 ul#book-search-results {
@@ -52,16 +53,32 @@ ul#book-search-results {
   margin: 0;
   list-style-type: none;
   float: left;
-  width: 100%;
-  background-color: white;
-  z-index: 10;
+  width: 30em;
+  max-height: 700px;
+  overflow-y: scroll;
+  border-radius: 6px;
+
+  z-index: 1;
   a b mark {
     background-color: #B8E1F3;
   }
 }
 
-ul#book-search-results li small {
+ul#book-search-results li {
   color: rgb(112, 128, 144);
+  background-color: white;
+  border-bottom: 1px solid #e7e8eb;
+  padding-bottom: 15px;
+  padding-left: 10px;
+  margin: 0px;
+  display: grid;
+}
+
+
+
+ul#book-search-results li p {
+   font-weight: bold;
+    margin-bottom: 4px;
 }
 
 .book-section-flat {

--- a/docs/assets/_custom.scss
+++ b/docs/assets/_custom.scss
@@ -45,7 +45,6 @@ li.navigation-icon-pad {
 
 #book-search-results {
   position: absolute;
-  top: 110px;
 }
 
 ul#book-search-results {
@@ -53,7 +52,7 @@ ul#book-search-results {
   margin: 0;
   list-style-type: none;
   float: left;
-  width: 30em;
+  width: 100%;
   max-height: 700px;
   overflow-y: scroll;
   border-radius: 6px;

--- a/docs/assets/search.js
+++ b/docs/assets/search.js
@@ -93,7 +93,7 @@
     const searchHits = window.pages.filter(page => page.content.toLowerCase().includes(input.value.toLowerCase()) )
     searchHits.forEach(function (page) {
 
-      var contentPreview = getSearchPreview(page, input.value, 30);
+      var contentPreview = getSearchPreview(page, input.value, 50);
 
       const li = element('<li><p></p><small></small></li>');
       const p = li.querySelector('p'), small = li.querySelector('small');

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -15,6 +15,16 @@
     </aside>
 
     <div class="book-page">
+      <div class="book-search">
+        <input type="text" id="book-search-input" placeholder="{{ i18n "Search" }}" aria-label="{{ i18n "Search" }}" maxlength="64" data-hotkeys="s/" />
+      </div>
+      <div >
+        <ul id="book-search-results">
+          <!--Reserve a <li> to solve safari compatibility problem-->
+          <li id="liFirst" style="background-color:#e7e8eb00; border-bottom:#e7e8eb00; color:#e7e8eb00;">.</li>
+        </ul>
+      </div>
+      </br>
       <header class="book-header">
         {{ template "header" . }} <!-- Mobile layout header -->
       </header>

--- a/docs/layouts/partials/docs/search.html
+++ b/docs/layouts/partials/docs/search.html
@@ -1,6 +1,5 @@
 {{ if default true .Site.Params.BookSearch }}
 <div class="book-search">
-  <input type="text" id="book-search-input" placeholder="{{ i18n "Search" }}" aria-label="{{ i18n "Search" }}" maxlength="64" data-hotkeys="s/" />
   <div class="book-search-spinner hidden"></div>
   <a href="https://github.com/apache/iceberg" target="_blank">
     <img src="{{ .Site.BaseURL }}/img/GitHub-Mark.png" target="_blank" class="top-external-icon"/>

--- a/docs/layouts/partials/docs/search.html
+++ b/docs/layouts/partials/docs/search.html
@@ -2,7 +2,6 @@
 <div class="book-search">
   <input type="text" id="book-search-input" placeholder="{{ i18n "Search" }}" aria-label="{{ i18n "Search" }}" maxlength="64" data-hotkeys="s/" />
   <div class="book-search-spinner hidden"></div>
-  <ul id="book-search-results"></ul>
   <a href="https://github.com/apache/iceberg" target="_blank">
     <img src="{{ .Site.BaseURL }}/img/GitHub-Mark.png" target="_blank" class="top-external-icon"/>
   </a>

--- a/docs/themes/hugo-book/layouts/_default/baseof.html
+++ b/docs/themes/hugo-book/layouts/_default/baseof.html
@@ -15,6 +15,13 @@
     </aside>
 
     <div class="book-page">
+      <div >
+        <ul id="book-search-results">
+          <!--Reserve a <li> to solve safari compatibility problem-->
+          <li id="liFirst" style="background-color:#e7e8eb00; border-bottom:#e7e8eb00; color:#e7e8eb00;">.</li>
+        </ul>
+      </div>
+      </br>
       <header class="book-header">
         {{ template "header" . }} <!-- Mobile layout header -->
       </header>


### PR DESCRIPTION
fix issue https://github.com/apache/iceberg/issues/4095

it's hard to widen the result view below the search input, so I put it on the right side
@RussellSpitzer 