### PR TITLE
Docs: Add copyright style and configuring copyright for IDEA

### DIFF
--- a/landing-page/content/common/contribute.md
+++ b/landing-page/content/common/contribute.md
@@ -81,6 +81,37 @@ Point to [intellij-java-palantir-style.xml](https://github.com/apache/iceberg/bl
 
 See also the IntelliJ [Code Style docs](https://www.jetbrains.com/help/idea/copying-code-style-settings.html) and [Reformat Code docs](https://www.jetbrains.com/help/idea/reformat-and-rearrange-code.html) for additional details.
 
+### Configuring Copyright for IntelliJ IDEA
+
+Every file needs to include the Apache license as a header. This can be automated in IntelliJ by
+adding a Copyright profile:
+
+1. In the **Settings/Preferences** dialog go to **Editor → Copyright → Copyright Profiles**.
+2. Add a new profile and name it **Apache**.
+3. Add the following text as the license text:
+
+   ```
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+   ```
+4. Go to **Editor → Copyright** and choose the **Apache** profile as the default profile for this
+   project.
+5. Click **Apply**.
+
 ## Iceberg Code Contribution Guidelines
 
 ### Style
@@ -90,6 +121,29 @@ For Java styling, check out the section
 documentation site.
 
 For Python, please use the tox command `tox -e format` to apply autoformatting to the project.
+
+### Copyright
+
+Each file must include the Apache license information as a header.
+
+```
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+```
 
 ### Java style guidelines
 


### PR DESCRIPTION
Add a copyright style in the ` Iceberg Code Contribution Guidelines` section of `contribute.md`.
Add configuring copyright for IDEA in the `Setting up IDE and Code Style` section of `contribute.md`.