### PR TITLE
Fix copy command in how-to-release

### DIFF
--- a/landing-page/content/common/how-to-release.md
+++ b/landing-page/content/common/how-to-release.md
@@ -300,7 +300,8 @@ git push --set-upstream apache <VERSION>
 ```
 2. Copy the versioned docs from the `iceberg` repo into the `iceberg-docs` repo
 ```shell
-cp -r ../iceberg/docs ../iceberg-docs/docs/content/docs
+rm -rf ../iceberg-docs/docs/content
+cp -r ../iceberg/docs ../iceberg-docs/docs/content
 ```
 3. Commit the changes and open a PR against the `<VERSION>` branch in the `iceberg-docs` repo
 


### PR DESCRIPTION
This fixes a small typo in the command to copy over the versioned docs. What should happen is that the content directory should be replaced in it's entirety by the docs directory from the iceberg repo. That way if pages are removed there, that's reflected here.