### PR TITLE
Add titles to spec pages

### DIFF
--- a/landing-page/content/common/puffin-spec.md
+++ b/landing-page/content/common/puffin-spec.md
@@ -1,6 +1,7 @@
 ---
+title: "Puffin Spec"
 url: puffin-spec
-toc: false
+disableSidebar: true
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/landing-page/content/common/spec.md
+++ b/landing-page/content/common/spec.md
@@ -1,7 +1,7 @@
 ---
+title: "Spec"
 url: spec
-aliases:
-    - "spec"
+disableSidebar: true
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/landing-page/content/common/view-spec.md
+++ b/landing-page/content/common/view-spec.md
@@ -1,3 +1,8 @@
+---
+title: "View Spec"
+url: view-spec
+disableSidebar: true
+---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more
  - contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
This fixes the failing build caused by some missing front-matter in the new spec pages.