### PR TITLE
[0.13.2]: Add release date of 0.13.2

### DIFF
--- a/landing-page/content/common/release-notes.md
+++ b/landing-page/content/common/release-notes.md
@@ -68,7 +68,7 @@ To add a dependency on Iceberg in Maven, add the following to your `pom.xml`:
 ```
 ## 0.13.2 Release Notes
 
-Apache Iceberg 0.13.2 was released on June XXth, 2022.
+Apache Iceberg 0.13.2 was released on June 15th, 2022.
 
 **Important bug fixes and changes:**
 


### PR DESCRIPTION
Release date at present shows up as June XXth, 2022 in release notes.

This pr attempts to update this with 15th june, based on release announcement : https://lists.apache.org/thread/rgx2q5kzzcgorhv494f37pstpbp5f6cy


cc @samredai @nastra 