### PR TITLE
Hardcode logo href to https://iceberg.apache.org/

### DIFF
--- a/iceberg-theme/layouts/partials/header.html
+++ b/iceberg-theme/layouts/partials/header.html
@@ -23,7 +23,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="page-scroll navbar-brand" href="{{ .Site.BaseURL }}"><img class="top-navbar-logo" src="{{ .Site.BaseURL }}/img/iceberg-logo-icon.png"/> {{ .Site.Title }}</a>
+                <a class="page-scroll navbar-brand" href="https://iceberg.apache.org/"><img class="top-navbar-logo" src="{{ .Site.BaseURL }}/img/iceberg-logo-icon.png"/> {{ .Site.Title }}</a>
             </div>
                 {{ partial "search.html" . }}
                 {{ partial "version-dropdown.html" . }}


### PR DESCRIPTION
This hardcodes the logo+"Apache Iceberg" in the top left corner to always link to https://iceberg.apache.org. This way, whether a user is on the landing-page or a versioned docs site, it will always link to the homepage.