### PR TITLE
[Hotfix-0.13.2] Add missing Releases to topnav

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -32,6 +32,7 @@ home = [ "HTML", "RSS", "SearchIndex" ]
   topnav = [
     { name = "Quickstart", pre = "relative", url = "../../spark-quickstart", weight = 100 },
     { name = "Docs", url = "/docs/latest", weight = 200 },
+    { name = "Releases", pre = "relative", url = "../../releases", weight = 600 },
     { name = "Blogs", pre = "relative", url = "../../blogs", weight = 998 },
     { name = "Talks", pre = "relative", url = "../../talks", weight = 999 },
     { name = "Roadmap", pre = "relative", url = "../../roadmap", weight = 997 },


### PR DESCRIPTION
This adds the "Releases" link which is missing from the topnav.