### PR TITLE
Fix top menu shifting when switching between landing page and docs site

### DIFF
--- a/iceberg-theme/layouts/index.html
+++ b/iceberg-theme/layouts/index.html
@@ -18,8 +18,8 @@
     {{ partial "body.html" . }}
 {{ else }}
     {{ partial "head.html" . }}
-    <div id="content">
     {{ partial "header.html" . }}
+    <div id="content">
     {{ partial "about.html" . }}
     {{ partial "services.html" . }}
     {{ partial "pricing.html" . }}

--- a/iceberg-theme/layouts/partials/about.html
+++ b/iceberg-theme/layouts/partials/about.html
@@ -13,6 +13,29 @@
 <!-- - See the License for the specific language governing permissions and-->
 <!-- - limitations under the License.-->
 
+{{ if and .IsHome (not .Site.Params.disableHome) }}
+    <!-- Show the Iceberg marketing splash content only when on the homepage-->
+    <section id="intro">
+        <div class="intro-header">
+            <div class="container">
+            <div class="row">
+                <div class="col-lg-12">
+                <div class="intro-message">
+                    <h1>{{ .Site.Title }}</h1>
+                    <h3>{{ .Site.Params.description }}</h3>
+                    <hr class="intro-divider">
+                    {{ if isset .Site.Params "social" }}
+                    <ul class="list-inline intro-social-buttons">
+                            {{ partial "social.html" . }}
+                    </ul>
+                    {{ end }}
+                </div>
+                </div>
+            </div>
+            </div>
+        </div>
+    </section>
+{{ end }}
 <section id="about" class="container content-section text-center">
 {{ range where .Site.RegularPages "Section" "about" | first 1 }}
 	<div class="row">

--- a/iceberg-theme/layouts/partials/header.html
+++ b/iceberg-theme/layouts/partials/header.html
@@ -75,26 +75,3 @@
             </topsection>
     </nav>
 {{ partial "search-results.html" . }}
-{{ if and .IsHome (not .Site.Params.disableHome) }}
-    <!-- Show the Iceberg marketing splash content only when on the homepage-->
-    <section id="intro">
-        <div class="intro-header">
-            <div class="container">
-            <div class="row">
-                <div class="col-lg-12">
-                <div class="intro-message">
-                    <h1>{{ .Site.Title }}</h1>
-                    <h3>{{ .Site.Params.description }}</h3>
-                    <hr class="intro-divider">
-                    {{ if isset .Site.Params "social" }}
-                    <ul class="list-inline intro-social-buttons">
-                            {{ partial "social.html" . }}
-                    </ul>
-                    {{ end }}
-                </div>
-                </div>
-            </div>
-            </div>
-        </div>
-    </section>
-{{ end }}


### PR DESCRIPTION
This fixes a small issue where the top nav menu shifts very slightly when you switch between the home page and any other page. This was caused by some of the home page content actually being rendered in the header partial outside of the content div, which added a slight padding to the top navigation bar for the scroll bar. This change brings the header out of the content div so the scroll bar starts right below the navbar.