### PR TITLE
Change config file to config dir with version-based overrides

### DIFF
--- a/config/0.12.1/menu.toml
+++ b/config/0.12.1/menu.toml
@@ -13,5 +13,5 @@ main = [ # Main menu, docs site left nav
   { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
   { name = "Integrations", weight = 1100 },
   { name = "API", weight = 1200},
-  { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"
+  { name = "Javadoc", pre = "relative", url = "../../javadoc/0.12.1", weight = 1300}
 ]

--- a/config/0.12.1/menu.toml
+++ b/config/0.12.1/menu.toml
@@ -1,0 +1,17 @@
+main = [ # Main menu, docs site left nav
+  { name = "Introduction", url = "/", weight = 1},
+  { name = "Tables", weight = 100 },
+  { name = "Spark", weight = 200},
+  { name = "Flink", weight = 300},
+  { name = "Trino", identifier = "_trino", weight = 500, url = "https://trino.io/docs/current/connector/iceberg.html" },
+  { name = "Presto", identifier = "_presto", weight = 600, url = "https://prestodb.io/docs/current/connector/iceberg.html" },
+  { name = "Dremio", identifier = "_dremio", weight = 700, url = "https://docs.dremio.com/data-formats/apache-iceberg/" },
+  { name = "StarRocks", identifier = "_starrocks", weight = 701, url = "https://docs.starrocks.com/en-us/main/using_starrocks/External_table#apache-iceberg-external-table" },
+  { name = "Amazon Athena", identifier = "_athena", weight = 800, url = "https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html" },
+  { name = "Amazon EMR", identifier = "_emr", weight = 900, url = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html" },
+  { name = "Impala", identifier = "_impala", weight = 1000, url = "https://impala.apache.org/docs/build/html/topics/impala_iceberg.html" },
+  { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
+  { name = "Integrations", weight = 1100 },
+  { name = "API", weight = 1200},
+  { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"
+]

--- a/config/0.12.1/params.toml
+++ b/config/0.12.1/params.toml
@@ -1,0 +1,1 @@
+versions.iceberg = "0.12.1"

--- a/config/0.13.0/menu.toml
+++ b/config/0.13.0/menu.toml
@@ -1,0 +1,17 @@
+main = [ # Main menu, docs site left nav
+  { name = "Introduction", url = "/", weight = 1},
+  { name = "Tables", weight = 100 },
+  { name = "Spark", weight = 200},
+  { name = "Flink", weight = 300},
+  { name = "Trino", identifier = "_trino", weight = 500, url = "https://trino.io/docs/current/connector/iceberg.html" },
+  { name = "Presto", identifier = "_presto", weight = 600, url = "https://prestodb.io/docs/current/connector/iceberg.html" },
+  { name = "Dremio", identifier = "_dremio", weight = 700, url = "https://docs.dremio.com/data-formats/apache-iceberg/" },
+  { name = "StarRocks", identifier = "_starrocks", weight = 701, url = "https://docs.starrocks.com/en-us/main/using_starrocks/External_table#apache-iceberg-external-table" },
+  { name = "Amazon Athena", identifier = "_athena", weight = 800, url = "https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html" },
+  { name = "Amazon EMR", identifier = "_emr", weight = 900, url = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html" },
+  { name = "Impala", identifier = "_impala", weight = 1000, url = "https://impala.apache.org/docs/build/html/topics/impala_iceberg.html" },
+  { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
+  { name = "Integrations", weight = 1100 },
+  { name = "API", weight = 1200},
+  { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"
+]

--- a/config/0.13.0/params.toml
+++ b/config/0.13.0/params.toml
@@ -1,0 +1,1 @@
+versions.iceberg = "0.13.0"

--- a/config/0.13.1/menu.toml
+++ b/config/0.13.1/menu.toml
@@ -13,5 +13,5 @@ main = [ # Main menu, docs site left nav
   { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
   { name = "Integrations", weight = 1100 },
   { name = "API", weight = 1200},
-  { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"
+  { name = "Javadoc", pre = "relative", url = "../../javadoc/0.13.1", weight = 1300}
 ]

--- a/config/0.13.1/menu.toml
+++ b/config/0.13.1/menu.toml
@@ -1,0 +1,17 @@
+main = [ # Main menu, docs site left nav
+  { name = "Introduction", url = "/", weight = 1},
+  { name = "Tables", weight = 100 },
+  { name = "Spark", weight = 200},
+  { name = "Flink", weight = 300},
+  { name = "Trino", identifier = "_trino", weight = 500, url = "https://trino.io/docs/current/connector/iceberg.html" },
+  { name = "Presto", identifier = "_presto", weight = 600, url = "https://prestodb.io/docs/current/connector/iceberg.html" },
+  { name = "Dremio", identifier = "_dremio", weight = 700, url = "https://docs.dremio.com/data-formats/apache-iceberg/" },
+  { name = "StarRocks", identifier = "_starrocks", weight = 701, url = "https://docs.starrocks.com/en-us/main/using_starrocks/External_table#apache-iceberg-external-table" },
+  { name = "Amazon Athena", identifier = "_athena", weight = 800, url = "https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html" },
+  { name = "Amazon EMR", identifier = "_emr", weight = 900, url = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html" },
+  { name = "Impala", identifier = "_impala", weight = 1000, url = "https://impala.apache.org/docs/build/html/topics/impala_iceberg.html" },
+  { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
+  { name = "Integrations", weight = 1100 },
+  { name = "API", weight = 1200},
+  { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"
+]

--- a/config/0.13.1/params.toml
+++ b/config/0.13.1/params.toml
@@ -1,0 +1,1 @@
+versions.iceberg = "0.13.1"

--- a/config/0.13.2/menu.toml
+++ b/config/0.13.2/menu.toml
@@ -13,5 +13,5 @@ main = [ # Main menu, docs site left nav
   { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
   { name = "Integrations", weight = 1100 },
   { name = "API", weight = 1200},
-  { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"
+  { name = "Javadoc", pre = "relative", url = "../../javadoc/0.13.2", weight = 1300}
 ]

--- a/config/0.13.2/menu.toml
+++ b/config/0.13.2/menu.toml
@@ -1,0 +1,17 @@
+main = [ # Main menu, docs site left nav
+  { name = "Introduction", url = "/", weight = 1},
+  { name = "Tables", weight = 100 },
+  { name = "Spark", weight = 200},
+  { name = "Flink", weight = 300},
+  { name = "Trino", identifier = "_trino", weight = 500, url = "https://trino.io/docs/current/connector/iceberg.html" },
+  { name = "Presto", identifier = "_presto", weight = 600, url = "https://prestodb.io/docs/current/connector/iceberg.html" },
+  { name = "Dremio", identifier = "_dremio", weight = 700, url = "https://docs.dremio.com/data-formats/apache-iceberg/" },
+  { name = "StarRocks", identifier = "_starrocks", weight = 701, url = "https://docs.starrocks.com/en-us/main/using_starrocks/External_table#apache-iceberg-external-table" },
+  { name = "Amazon Athena", identifier = "_athena", weight = 800, url = "https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html" },
+  { name = "Amazon EMR", identifier = "_emr", weight = 900, url = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html" },
+  { name = "Impala", identifier = "_impala", weight = 1000, url = "https://impala.apache.org/docs/build/html/topics/impala_iceberg.html" },
+  { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
+  { name = "Integrations", weight = 1100 },
+  { name = "API", weight = 1200},
+  { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"
+]

--- a/config/0.13.2/params.toml
+++ b/config/0.13.2/params.toml
@@ -1,0 +1,1 @@
+versions.iceberg = "0.13.2"

--- a/config/0.14.0/menu.toml
+++ b/config/0.14.0/menu.toml
@@ -13,5 +13,5 @@ main = [ # Main menu, docs site left nav
   { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
   { name = "Integrations", weight = 1100 },
   { name = "API", weight = 1200},
-  { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"
+  { name = "Javadoc", pre = "relative", url = "../../javadoc/0.14.0", weight = 1300}
 ]

--- a/config/0.14.0/menu.toml
+++ b/config/0.14.0/menu.toml
@@ -1,0 +1,17 @@
+main = [ # Main menu, docs site left nav
+  { name = "Introduction", url = "/", weight = 1},
+  { name = "Tables", weight = 100 },
+  { name = "Spark", weight = 200},
+  { name = "Flink", weight = 300},
+  { name = "Trino", identifier = "_trino", weight = 500, url = "https://trino.io/docs/current/connector/iceberg.html" },
+  { name = "Presto", identifier = "_presto", weight = 600, url = "https://prestodb.io/docs/current/connector/iceberg.html" },
+  { name = "Dremio", identifier = "_dremio", weight = 700, url = "https://docs.dremio.com/data-formats/apache-iceberg/" },
+  { name = "StarRocks", identifier = "_starrocks", weight = 701, url = "https://docs.starrocks.com/en-us/main/using_starrocks/External_table#apache-iceberg-external-table" },
+  { name = "Amazon Athena", identifier = "_athena", weight = 800, url = "https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html" },
+  { name = "Amazon EMR", identifier = "_emr", weight = 900, url = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html" },
+  { name = "Impala", identifier = "_impala", weight = 1000, url = "https://impala.apache.org/docs/build/html/topics/impala_iceberg.html" },
+  { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
+  { name = "Integrations", weight = 1100 },
+  { name = "API", weight = 1200},
+  { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"
+]

--- a/config/0.14.0/params.toml
+++ b/config/0.14.0/params.toml
@@ -1,0 +1,1 @@
+versions.iceberg = "0.14.0"

--- a/config/0.14.1/menu.toml
+++ b/config/0.14.1/menu.toml
@@ -13,5 +13,5 @@ main = [ # Main menu, docs site left nav
   { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
   { name = "Integrations", weight = 1100 },
   { name = "API", weight = 1200},
-  { name = "Javadoc", pre = "relative", url = "../../javadoc/0.13.0", weight = 1300}
+  { name = "Javadoc", pre = "relative", url = "../../javadoc/0.14.1", weight = 1300}
 ]

--- a/config/0.14.1/params.toml
+++ b/config/0.14.1/params.toml
@@ -1,0 +1,1 @@
+versions.iceberg = "0.14.1"

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -10,7 +10,7 @@ theme= "iceberg-theme"
   search = true
   versions.iceberg = "" # This is populated by the github deploy workflow and is equal to the branch name
   versions.nessie = "0.18.0"
-  latestVersions.iceberg = "0.14.0"  # This is used for the version badge on the "latest" site version
+  latestVersions.iceberg = "0.14.1"  # This is used for the version badge on the "latest" site version
   BookSection='docs' # This determines which directory will inform the left navigation menu
   disableHome=true
 
@@ -24,6 +24,7 @@ home = [ "HTML", "RSS", "SearchIndex" ]
 [menu]
   versions = [
     { name = "latest", pre = "relative", url = "../latest", weight = 1 },
+    { name = "0.14.1", pre = "relative", url = "../0.14.1", weight = 995 },
     { name = "0.14.0", pre = "relative", url = "../0.14.0", weight = 996 },
     { name = "0.13.2", pre = "relative", url = "../0.13.2", weight = 997 },
     { name = "0.13.1", pre = "relative", url = "../0.13.1", weight = 998 },
@@ -33,17 +34,18 @@ home = [ "HTML", "RSS", "SearchIndex" ]
   topnav = [
     { name = "Quickstart", url = "/spark-quickstart", weight = 100 },
     { name = "Docs", url = "/docs/latest", weight = 200 },
-    { name = "Releases", pre = "relative", url = "../../releases", weight = 600 },
-    { name = "Blogs", pre = "relative", url = "../../blogs", weight = 998 },
-    { name = "Talks", pre = "relative", url = "../../talks", weight = 999 },
-    { name = "Roadmap", pre = "relative", url = "../../roadmap", weight = 997 },
+    { name = "Releases", url = "/releases", weight = 600 },
+    { name = "Roadmap", url = "/roadmap", weight = 997 },
+    { name = "Blogs", url = "/blogs", weight = 998 },
+    { name = "Talks", url = "/talks", weight = 999 },
+    { name = "Vendors", url = "/vendors", weight = 1000 },
     { name = "Project", weight = 1100 },
-    { name = "Community", parent = "Project", pre = "relative", url = "../../community", weight = 100 },
-    { name = "Spec", parent = "Project", pre = "relative", url = "../../spec", weight = 200 },
-    { name = "View Spec", parent = "Project", pre = "relative", url = "../../view-spec", weight = 300 },
-    { name = "Puffin Spec", parent = "Project", pre = "relative", url = "../../puffin-spec", weight = 400 },
-    { name = "How To Release", parent = "Project", pre = "relative", url = "../../how-to-release", weight = 500 },
-    { name = "Terms", parent = "Project", pre = "relative", url = "../../terms", weight = 600 },
+    { name = "Join", parent = "Project", url = "/community", weight = 100 },
+    { name = "Spec", url = "/spec", parent = "Project", weight = 200 },
+    { name = "View Spec", url = "/view-spec", parent = "Project", weight = 300 },
+    { name = "Puffin Spec", url = "/puffin-spec", parent = "Project", weight = 400 },
+    { name = "How To Release", parent = "Project", url = "/how-to-release", weight = 500 },
+    { name = "Terms", url = "/terms", parent = "Project", weight = 600 },
     { name = "ASF", weight = 1200 },
     { name = "License", identifier = "_license", parent = "ASF", url = "https://www.apache.org/licenses/" },
     { name = "Security", identifier = "_security", parent = "ASF", url = "https://www.apache.org/security/" },

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,0 +1,70 @@
+baseURL = ""  # This is populated by the github deploy workflow and is equal to "<domainName>/docs/<version|latest>"
+canonifyURLs = "true"
+relativeURLs = "true"
+languageCode = "en-us"
+title = "Apache Iceberg"
+theme= "iceberg-theme"
+
+[params]
+  siteType = "docs"
+  search = true
+  versions.iceberg = "" # This is populated by the github deploy workflow and is equal to the branch name
+  versions.nessie = "0.18.0"
+  latestVersions.iceberg = "0.14.0"  # This is used for the version badge on the "latest" site version
+  BookSection='docs' # This determines which directory will inform the left navigation menu
+  disableHome=true
+
+[outputFormats.SearchIndex]
+baseName = "search"
+mediaType = "application/json"
+
+[outputs]
+home = [ "HTML", "RSS", "SearchIndex" ]
+
+[menu]
+  versions = [
+    { name = "latest", pre = "relative", url = "../latest", weight = 1 },
+    { name = "0.14.0", pre = "relative", url = "../0.14.0", weight = 996 },
+    { name = "0.13.2", pre = "relative", url = "../0.13.2", weight = 997 },
+    { name = "0.13.1", pre = "relative", url = "../0.13.1", weight = 998 },
+    { name = "0.13.0", pre = "relative", url = "../0.13.0", weight = 999 },
+    { name = "0.12.1", pre = "relative", url = "../0.12.1", weight = 1000 }
+  ]
+  topnav = [
+    { name = "Quickstart", url = "/spark-quickstart", weight = 100 },
+    { name = "Docs", url = "/docs/latest", weight = 200 },
+    { name = "Releases", pre = "relative", url = "../../releases", weight = 600 },
+    { name = "Blogs", pre = "relative", url = "../../blogs", weight = 998 },
+    { name = "Talks", pre = "relative", url = "../../talks", weight = 999 },
+    { name = "Roadmap", pre = "relative", url = "../../roadmap", weight = 997 },
+    { name = "Project", weight = 1100 },
+    { name = "Community", parent = "Project", pre = "relative", url = "../../community", weight = 100 },
+    { name = "Spec", parent = "Project", pre = "relative", url = "../../spec", weight = 200 },
+    { name = "View Spec", parent = "Project", pre = "relative", url = "../../view-spec", weight = 300 },
+    { name = "Puffin Spec", parent = "Project", pre = "relative", url = "../../puffin-spec", weight = 400 },
+    { name = "How To Release", parent = "Project", pre = "relative", url = "../../how-to-release", weight = 500 },
+    { name = "Terms", parent = "Project", pre = "relative", url = "../../terms", weight = 600 },
+    { name = "ASF", weight = 1200 },
+    { name = "License", identifier = "_license", parent = "ASF", url = "https://www.apache.org/licenses/" },
+    { name = "Security", identifier = "_security", parent = "ASF", url = "https://www.apache.org/security/" },
+    { name = "Sponsors", identifier = "_sponsors", parent = "ASF", url = "https://www.apache.org/foundation/thanks.html" },
+    { name = "Donate", identifier = "_donate", parent = "ASF", url = "https://www.apache.org/foundation/sponsorship.html" },
+    { name = "Events", identifier = "_events", parent = "ASF", url = "https://www.apache.org/events/current-event.html" },
+  ]
+  main = [ # Main menu, docs site left nav
+    { name = "Introduction", url = "/", weight = 1},
+    { name = "Tables", weight = 100 },
+    { name = "Spark", weight = 200},
+    { name = "Flink", weight = 300},
+    { name = "Trino", identifier = "_trino", weight = 500, url = "https://trino.io/docs/current/connector/iceberg.html" },
+    { name = "Presto", identifier = "_presto", weight = 600, url = "https://prestodb.io/docs/current/connector/iceberg.html" },
+    { name = "Dremio", identifier = "_dremio", weight = 700, url = "https://docs.dremio.com/data-formats/apache-iceberg/" },
+    { name = "StarRocks", identifier = "_starrocks", weight = 701, url = "https://docs.starrocks.com/en-us/main/using_starrocks/External_table#apache-iceberg-external-table" },
+    { name = "Amazon Athena", identifier = "_athena", weight = 800, url = "https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html" },
+    { name = "Amazon EMR", identifier = "_emr", weight = 900, url = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html" },
+    { name = "Impala", identifier = "_impala", weight = 1000, url = "https://impala.apache.org/docs/build/html/topics/impala_iceberg.html" },
+    { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
+    { name = "Integrations", weight = 1100 },
+    { name = "API", weight = 1200},
+    { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"
+  ]

--- a/config/_default/menu.toml
+++ b/config/_default/menu.toml
@@ -1,0 +1,29 @@
+versions = [
+  { name = "latest", pre = "relative", url = "../latest", weight = 1 },
+  { name = "0.14.0", pre = "relative", url = "../0.14.0", weight = 996 },
+  { name = "0.13.2", pre = "relative", url = "../0.13.2", weight = 997 },
+  { name = "0.13.1", pre = "relative", url = "../0.13.1", weight = 998 },
+  { name = "0.13.0", pre = "relative", url = "../0.13.0", weight = 999 },
+  { name = "0.12.1", pre = "relative", url = "../0.12.1", weight = 1000 }
+]
+topnav = [
+  { name = "Quickstart", url = "/spark-quickstart", weight = 100 },
+  { name = "Docs", url = "/docs/latest", weight = 200 },
+  { name = "Releases", pre = "relative", url = "../../releases", weight = 600 },
+  { name = "Blogs", pre = "relative", url = "../../blogs", weight = 998 },
+  { name = "Talks", pre = "relative", url = "../../talks", weight = 999 },
+  { name = "Roadmap", pre = "relative", url = "../../roadmap", weight = 997 },
+  { name = "Project", weight = 1100 },
+  { name = "Community", parent = "Project", pre = "relative", url = "../../community", weight = 100 },
+  { name = "Spec", parent = "Project", pre = "relative", url = "../../spec", weight = 200 },
+  { name = "View Spec", parent = "Project", pre = "relative", url = "../../view-spec", weight = 300 },
+  { name = "Puffin Spec", parent = "Project", pre = "relative", url = "../../puffin-spec", weight = 400 },
+  { name = "How To Release", parent = "Project", pre = "relative", url = "../../how-to-release", weight = 500 },
+  { name = "Terms", parent = "Project", pre = "relative", url = "../../terms", weight = 600 },
+  { name = "ASF", weight = 1200 },
+  { name = "License", identifier = "_license", parent = "ASF", url = "https://www.apache.org/licenses/" },
+  { name = "Security", identifier = "_security", parent = "ASF", url = "https://www.apache.org/security/" },
+  { name = "Sponsors", identifier = "_sponsors", parent = "ASF", url = "https://www.apache.org/foundation/thanks.html" },
+  { name = "Donate", identifier = "_donate", parent = "ASF", url = "https://www.apache.org/foundation/sponsorship.html" },
+  { name = "Events", identifier = "_events", parent = "ASF", url = "https://www.apache.org/events/current-event.html" },
+]

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,0 +1,6 @@
+siteType = "docs"
+search = true
+versions.nessie = "0.18.0"
+versions.iceberg = "0.14.0"
+BookSection='docs' # This determines which directory will inform the left navigation menu
+disableHome=true

--- a/config/landing-page/config.toml
+++ b/config/landing-page/config.toml
@@ -1,0 +1,69 @@
+baseURL = "" # This is populated by the github deploy workflow and is equal to "<domainName>"
+languageCode = "en-us"
+title = "Apache Iceberg"
+theme = "iceberg-theme"
+sectionPagesMenu = "main"
+
+[params]
+  siteType = "landing-page"
+  search = true
+  description = "The open table format for analytic datasets."
+  latestVersions.iceberg = "0.14.0"
+  docsBaseURL = ""
+
+[[params.social]]
+  title = "Community"
+  icon = "comments"
+  rel_url = "community"
+[[params.social]]
+  title = "github"
+  icon = "github"
+  url = "https://github.com/apache/iceberg"
+[[params.social]]
+  title = "slack"
+  icon = "slack"
+  url = "https://join.slack.com/t/apache-iceberg/shared_invite/zt-tlv0zjz6-jGJEkHfb1~heMCJA3Uycrg"  
+
+[outputFormats.SearchIndex]
+baseName = "search"
+mediaType = "application/json"
+
+[outputs]
+home = [ "HTML", "RSS", "SearchIndex" ]
+
+[menu]
+  versions = [
+    { name = "latest", url = "/docs/latest", weight = 1 },
+    { name = "0.14.0", url = "/docs/0.14.0", weight = 996 },
+    { name = "0.13.2", url = "/docs/0.13.2", weight = 997 },
+    { name = "0.13.1", url = "/docs/0.13.1", weight = 998 },
+    { name = "0.13.0", url = "/docs/0.13.0", weight = 999 },
+    { name = "0.12.1", url = "/docs/0.12.1", weight = 1000 }
+  ]
+  topnav = [
+    { name = "Quickstart", url = "/spark-quickstart", weight = 100 },
+    { name = "Docs", url = "/docs/latest", weight = 200 },
+    { name = "Releases", url = "/releases", weight = 600 },
+    { name = "Blogs", url = "/blogs", weight = 998 },
+    { name = "Talks", url = "/talks", weight = 999 },
+    { name = "Roadmap", url = "/roadmap", weight = 997 },
+    { name = "Project", weight = 1100 },
+    { name = "Join", parent = "Project", url = "/community", weight = 100 },
+    { name = "Spec", url = "/spec", parent = "Project", weight = 200 },
+    { name = "View Spec", url = "/view-spec", parent = "Project", weight = 300 },
+    { name = "Puffin Spec", url = "/puffin-spec", parent = "Project", weight = 400 },
+    { name = "How To Release", parent = "Project", url = "/how-to-release", weight = 500 },
+    { name = "Terms", url = "/terms", parent = "Project", weight = 600 },
+    { name = "ASF", weight = 1200 },
+    { name = "License", identifier = "_license", parent = "ASF", url = "https://www.apache.org/licenses/" },
+    { name = "Security", identifier = "_security", parent = "ASF", url = "https://www.apache.org/security/" },
+    { name = "Sponsors", identifier = "_sponsors", parent = "ASF", url = "https://www.apache.org/foundation/thanks.html" },
+    { name = "Donate", identifier = "_donate", parent = "ASF", url = "https://www.apache.org/foundation/sponsorship.html" },
+    { name = "Events", identifier = "_events", parent = "ASF", url = "https://www.apache.org/events/current-event.html" },
+  ]
+  quickstarts = [
+    { name = "Spark and Iceberg Quickstart", weight = 100, url = "spark-quickstart", post = "This quickstart will get you up and running with an Iceberg and Spark environment, including sample notebooks." }
+  ]
+
+[markup.goldmark.renderer]
+unsafe= true

--- a/config/landing-page/config.toml
+++ b/config/landing-page/config.toml
@@ -8,7 +8,7 @@ sectionPagesMenu = "main"
   siteType = "landing-page"
   search = true
   description = "The open table format for analytic datasets."
-  latestVersions.iceberg = "0.14.0"
+  latestVersions.iceberg = "0.14.1"
   docsBaseURL = ""
 
 [[params.social]]
@@ -34,6 +34,7 @@ home = [ "HTML", "RSS", "SearchIndex" ]
 [menu]
   versions = [
     { name = "latest", url = "/docs/latest", weight = 1 },
+    { name = "0.14.1", url = "/docs/0.14.1", weight = 995 },
     { name = "0.14.0", url = "/docs/0.14.0", weight = 996 },
     { name = "0.13.2", url = "/docs/0.13.2", weight = 997 },
     { name = "0.13.1", url = "/docs/0.13.1", weight = 998 },


### PR DESCRIPTION
This adds a config directory that can replace the individual config.toml files. During building we can use the --environment argument to select a set of overrides. You can read more about this in the hugo docs: https://gohugo.io/getting-started/configuration/#configuration-directory

```
config
├── 0.12.1
│   ├── menu.toml
│   └── params.toml
├── 0.13.0
│   ├── menu.toml
│   └── params.toml
├── 0.13.1
│   ├── menu.toml
│   └── params.toml
├── 0.13.2
│   ├── menu.toml
│   └── params.toml
├── 0.14.0  <-- Every version directory provides overrides: mainly 1) The version-specific leftnav 2) The "versions.iceberg" param which is used throughout the docs site
│   ├── menu.toml
│   └── params.toml
├── _default <-- This is the config, menu, and params section that's loaded as a base
│   ├── config.toml
│   ├── menu.toml
│   └── params.toml
├── landing-page  <-- Landing-page is much different than the docs sites so it essentially overrides the entire config.toml
│   └── config.toml
└── latest
```

As an example, assume we had the docs content in a `docs/content/0.14.0` directory (coming soon in a PR for the iceberg repo). We could build the site using the 0.14.0 config overrides and the 0.14.0 markdown files only.
```
VERSION=0.14.0
hugo -s docs -d ../public/docs/${VERSION} --contentDir content/${VERSION}/ --configDir ../config --environment ${VERSION}
```
- `-s docs` specifies to use docs as the root directory for the build (allows us to run this from the repo root)
- `-d ../public/docs/${VERSION}` tells hugo to build it in a "docs/0.14.0 sub-directory (the landing-page would be deployed to the root of the public directory
- `--contentDir content/${VERSION}/` tells hugo to look in the docs/content/0.14.0 directory for the markdown files
- `--configDir ../config` points to the config directory in the repo root to find the default config as well as all of the optional overrides
- `--environment ${VERSION}` selects the config/0.14.0 set of config overrides from the config directory