### PR TITLE
Update time-travel example on landing-page to use SQL

### DIFF
--- a/landing-page/content/services/time-travel.html
+++ b/landing-page/content/services/time-travel.html
@@ -25,16 +25,9 @@ excludeFromSearch: true
  -->
  <div class="termynal-container">
     <div id="termynal-time-travel" data-termynal data-ty-startDelay="6000" data-ty-typeDelay="20" data-ty-lineDelay="500">
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">spark.read.table("taxis").count()</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="sql>">select count(*) from nyc.taxis</span>
         <span data-ty>2,853,020</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">val ONE_DAY_MS=86400000</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">val NOW=System.currentTimeMillis()</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">val YESTERDAY=NOW - ONE_DAY_MS</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="scala>">(spark</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.read</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.option("as-of-timestamp", YESTERDAY)</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.table("taxis")</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="">.count())</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="sql>">select count(*) from nyc.taxis for version as of 2188465307835585443</span>
         <span data-ty>2,798,371</span>
     </div>
 </div>

--- a/landing-page/content/services/time-travel.html
+++ b/landing-page/content/services/time-travel.html
@@ -25,9 +25,11 @@ excludeFromSearch: true
  -->
  <div class="termynal-container">
     <div id="termynal-time-travel" data-termynal data-ty-startDelay="6000" data-ty-typeDelay="20" data-ty-lineDelay="500">
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="sql>">select count(*) from nyc.taxis</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="sql>">SELECT count(*) FROM  nyc.taxis</span>
         <span data-ty>2,853,020</span>
-        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="sql>">select count(*) from nyc.taxis for version as of 2188465307835585443</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="sql>">SELECT count(*) FROM  nyc.taxis FOR VERSION AS OF 2188465307835585443</span>
+        <span data-ty>2,798,371</span>
+        <span data-ty="input" data-ty-cursor="▋" data-ty-prompt="sql>">SELECT count(*) FROM nyc.taxis FOR TIMESTAMP AS OF TIMESTAMP '2022-01-01 00:00:00.000000 Z'</span>
         <span data-ty>2,798,371</span>
     </div>
 </div>


### PR DESCRIPTION
This updates the time-travel example on the home page to use the SQL `version as of` syntax.

<img width="1224" alt="Screen Shot 2022-08-09 at 9 52 47 AM" src="https://user-images.githubusercontent.com/43911210/183711349-ba2c1329-99f5-43e2-a186-9bb8f5b85820.png">
