### PR TITLE
Update AWS EMR doc link

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -61,7 +61,7 @@ home = [ "HTML", "RSS", "SearchIndex" ]
     { name = "Dremio", identifier = "_dremio", weight = 700, url = "https://docs.dremio.com/data-formats/apache-iceberg/" },
     { name = "StarRocks", identifier = "_starrocks", weight = 701, url = "https://docs.starrocks.com/en-us/main/using_starrocks/External_table#apache-iceberg-external-table" },
     { name = "Amazon Athena", identifier = "_athena", weight = 800, url = "https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html" },
-    { name = "Amazon EMR", identifier = "_emr", weight = 900, url = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html" },
+    { name = "Amazon EMR", identifier = "_emr", weight = 900, url = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html" },
     { name = "Impala", identifier = "_impala", weight = 1000, url = "https://impala.apache.org/docs/build/html/topics/impala_iceberg.html" },
     { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
     { name = "Integrations", weight = 1100 },


### PR DESCRIPTION
Looks like the link url from apache iceberg official doc page to emr is broken now ( Please visit the https://iceberg.apache.org/docs/latest/ and click the emr ). This PR just update the emr document url to the refreshed one: 

- https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
