### PR TITLE
Fix Docs link, change it to relative

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -31,7 +31,7 @@ home = [ "HTML", "RSS", "SearchIndex" ]
   ]
   topnav = [
     { name = "Quickstart", pre = "relative", url = "../../spark-quickstart", weight = 100 },
-    { name = "Docs", url = "/docs/latest", weight = 200 },
+    { name = "Docs", pre = "relative", url = "../../docs/latest", weight = 200 },
     { name = "Releases", pre = "relative", url = "../../releases", weight = 600 },
     { name = "Blogs", pre = "relative", url = "../../blogs", weight = 998 },
     { name = "Talks", pre = "relative", url = "../../talks", weight = 999 },


### PR DESCRIPTION
This fixes an issue where the docs link is broken if you click it while already on the docs site. This only fixes it for the latest docs site and this patch needs to be added to the other doc site versions.