### PR TITLE
Fix media query for sidenav hamburger

### DIFF
--- a/iceberg-theme/static/css/iceberg-theme.css
+++ b/iceberg-theme/static/css/iceberg-theme.css
@@ -372,6 +372,10 @@ i.fa.fa-chevron-down {
 
 @media screen and (max-width: 1280px) {
     div.sidebar { display: none; }  /* Hide the sidebar if the page is less than 1280px */
+    .navbar-toggle {
+        display: block;
+        margin-left: 15px;
+    }
   }
 
 /* Style for the hint shortcode */


### PR DESCRIPTION
This fixes the hamburger not showing up until the screen is very narrow. This means there's a deadzone in screen width where the sidebar is hidden but the toggle button is also hidden.