### PR TITLE
[main] Add workflow for merging search indexes

### DIFF
--- a/.github/workflows/merge-search-indexes.yml
+++ b/.github/workflows/merge-search-indexes.yml
@@ -1,0 +1,29 @@
+name: Merge Landing-Page and Latest Docs Site Search Indexes
+
+on: workflow_dispatch
+
+jobs:
+  merge-search-indexes:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone the asf-site branch
+        uses: actions/checkout@v3
+        with:
+          ref: asf-site
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Merge landing-page and docs site search indexes
+        run: python -c "import os; import json; combined = json.load(open('landingpagesearch.json')) + json.load(open('docs/latest/docssearch.json')); os.mkdir('out'); json.dump(combined, open('out/search.json', 'w'));"
+
+      - name: Deploy combined search index to asf-site branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          publish_branch: asf-site
+          destination_dir: ./
+          keep_files: true

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -15,7 +15,7 @@ theme= "iceberg-theme"
   disableHome=true
 
 [outputFormats.SearchIndex]
-baseName = "search"
+baseName = "docssearch"
 mediaType = "application/json"
 
 [outputs]

--- a/docs/layouts/index.searchindex.json
+++ b/docs/layouts/index.searchindex.json
@@ -1,0 +1,16 @@
+[
+    {{- $pages := where .Site.RegularPages "Params.excludeFromSearch" "!=" true -}}
+    {{- $pages := where $pages "Content" "not in" (slice nil "") -}}
+    {{- range $index, $page := $pages -}}
+        {{- if eq $page.Params.excludeFromSearch true -}}
+        {{ else }}
+          {{- if gt $index 0 -}} , {{- end -}}
+          {{- $uri := print "/docs/latest" $page.RelPermalink -}}
+          {{- $entry := dict "uri" $uri "title" $page.Title -}}
+          {{- $entry = merge $entry (dict "content" ($page.Plain | htmlUnescape)) -}}
+          {{- $entry = merge $entry (dict "description" $page.Description) -}}
+          {{- $entry = merge $entry (dict "categories" $page.Params.categories) -}}
+          {{- $entry | jsonify -}}
+        {{- end -}}
+    {{- end -}}
+  ]

--- a/landing-page/config.toml
+++ b/landing-page/config.toml
@@ -25,7 +25,7 @@ sectionPagesMenu = "main"
   url = "https://join.slack.com/t/apache-iceberg/shared_invite/zt-tlv0zjz6-jGJEkHfb1~heMCJA3Uycrg"  
 
 [outputFormats.SearchIndex]
-baseName = "search"
+baseName = "landingpagesearch"
 mediaType = "application/json"
 
 [outputs]


### PR DESCRIPTION
Since the landing-page and docs site are separate sites, they each generate their own search index. Currently these are generated in `./search.json` and `./docs/latest/search.json` in the `asf-site` branch.

This adds a workflow that can be run manually (`on: workflow_dispatch`) to merge these two search indexes into a single `./search.json` file that contains the index for both sites. It also renames the initially generated indexes to `landingpagesearch.json` and `docssearch.json` so as to make the merging idempotent. (new names will take effect on the next deployment of each site)

To show an example of how this works, I put together this small repo [merge-json-example](https://github.com/samredai/merge-json-example) and you can go to the Actions tab to see a run of the workflow. It combines a `./landingpagesearch.json` containing `[{"a": "b"}, {"c": "d"}]` with a `./docs/latest/docssearch.json` containing `[{"e": "f"}, {"g": "h"}]` into a `./search.json` file containing `[{"a": "b"}, {"c": "d"}, {"e": "f"}, {"g": "h"}]` (on the asf-site branch).

Before running this workflow, this PR as well as the PR #143 for the latest branch needs to be merged to deploy the initial search indexes under the new names.

### How it works

The actual merging happens on this inline python script in the workflow:
```yaml
run: python -c "import os; import json; combined = json.load(open('landingpagesearch.json')) + json.load(open('docs/latest/docssearch.json')); os.mkdir('out'); json.dump(combined, open('out/search.json', 'w'));"
```
The script is follow by a step that copies the `search.json` file to the root of the `asf-site` branch.