### PR TITLE
[latest] Update Doris url in latest docs site

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -63,7 +63,7 @@ home = [ "HTML", "RSS", "SearchIndex" ]
     { name = "Amazon Athena", identifier = "_athena", weight = 800, url = "https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html" },
     { name = "Amazon EMR", identifier = "_emr", weight = 900, url = "https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html" },
     { name = "Impala", identifier = "_impala", weight = 1000, url = "https://impala.apache.org/docs/build/html/topics/impala_iceberg.html" },
-    { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html" },
+    { name = "Doris", identifier = "_doris", weight = 1001, url = "https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris" },
     { name = "Integrations", weight = 1100 },
     { name = "API", weight = 1200},
     { name = "Javadoc", pre = "relative", url = "../../javadoc/latest", weight = 1300} # `url` is populated by the github deploy workflow and is equal to "../../javadoc/<branch name>"


### PR DESCRIPTION
This fixes the broken link for Doris on the `latest` branch