### PR TITLE
Change duplicated title -> "Spark Configuration"

### DIFF
--- a/docs/content/spark-configuration.md
+++ b/docs/content/spark-configuration.md
@@ -1,5 +1,5 @@
 ---
-title: "Configuration"
+title: "Spark Configuration"
 url: spark-configuration
 aliases:
     - "spark/spark-configuration"


### PR DESCRIPTION
The Spark Configuration is currently hidden because the title "Configuration" conflicts with the table configuration page which is also titled "Configuration". The hugo logic seems to require unique title names since it's used for the left navbar list.