### PR TITLE
fix: rollback buggy version of spark

### DIFF
--- a/landing-page/content/common/spark-quickstart.md
+++ b/landing-page/content/common/spark-quickstart.md
@@ -52,7 +52,7 @@ version: "3"
 
 services:
   spark-iceberg:
-    image: tabulario/spark-iceberg
+    image: tabulario/spark-iceberg:3.3.1_1.1.0
     container_name: spark-iceberg
     build: spark/
     depends_on:


### PR DESCRIPTION
The latest version of `spark-iceberg` cannot start `spark-sql`, users will be confused by error from unknown source. This should fix it.

```
NestedThrowables:
java.sql.SQLException: Unable to open a test connection to the given database. JDBC url = jdbc:derby:;databaseName=metastore_db;create=true, username = APP. Terminating connection pool (set lazyInit to true if you expect to start your database after your app). Original Exception: ------
java.sql.SQLException: Failed to start database 'metastore_db' with class loader jdk.internal.loader.ClassLoaders$AppClassLoader@5ffd2b27, see the next exception for details.
```