### PR TITLE
Fix: Added the "overflow" property for TableOfContents

### DIFF
--- a/iceberg-theme/static/css/iceberg-theme.css
+++ b/iceberg-theme/static/css/iceberg-theme.css
@@ -278,12 +278,14 @@ h4:hover a { visibility: visible}
 
 #toc {
     position: fixed;
+    overflow-y:auto;
     right: 0;
     top: 0;
     background-color:#FFF;
     top: 70px;
     font-size: 0.95rem;
     width: 260px;
+    height:100%;
     list-style-type: none;
     margin: 0 100px;
 }


### PR DESCRIPTION
In this page https://iceberg.apache.org/docs/latest/aws/ we can see there is a lot of items in TableOfContents and when we change the height of the browser window, some of the contents were not showing up in TableOfContents. So I've modified the iceberg-theme.css to add the overflow-y and height property for the "#toc" element.