### PR TITLE
Add calendars for community page and fix ordering

### DIFF
--- a/landing-page/content/common/join.md
+++ b/landing-page/content/common/join.md
@@ -26,6 +26,56 @@ Apache Iceberg tracks issues in GitHub and prefers to receive contributions as p
 
 Community discussions happen primarily on the dev mailing list, on apache-iceberg Slack workspace, and on specific GitHub issues.
 
+## Contribute
+
+See [Contributing](../../../contribute) for more details on how to contribute to Iceberg.
+
+## Issues
+
+Issues are tracked in GitHub:
+
+* [View open issues][open-issues]
+* [Open a new issue][new-issue]
+
+[open-issues]: https://github.com/apache/iceberg/issues
+[new-issue]: https://github.com/apache/iceberg/issues/new
+
+## Slack
+
+We use the [Apache Iceberg workspace](https://apache-iceberg.slack.com/) on Slack. To be invited, follow [this invite link](https://join.slack.com/t/apache-iceberg/shared_invite/zt-1uva9gyp1-TrLQl7o~nZ5PsTVgl6uoEQ).
+
+Please note that this link may occasionally break when Slack does an upgrade. If you encounter problems using it, please let us know by sending an email to <dev@iceberg.apache.org>.
+
+## Iceberg Community Events
+
+This calendar contians two calendar feeds:
+
+* Iceberg Community Events - Events such as conferences and meetups, aimed to educate and inspire Iceberg users.
+* Iceberg Dev Events - Events such as the triweekly Iceberg sync, aimed to discuss the project roadmap and how to implement features.
+
+You can subscribe to either or both of these calendars by clicking the "+ Google Calendar" icon on the bottom right.
+
+<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=UTC&title=Iceberg%20Community%20Events%20(UTC)&showNav=1&showPrint=0&showCalendars=1&mode=AGENDA&src=NTkzYmIwMGJmZTQ1N2QzMTkxNDEzNTBkZDI0Yzk2NGYzOWJkYmQ5ZmQyNDMyODFhODYzMmEwMDk2M2EyMWQ4NkBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&src=MzkwNWQ0OTJmMWI0NTBiYTA3MTJmMmFlNmFmYTc2ZWI3NTdmMTNkODUyMjBjYzAzYWE0NTI3ODg1YWRjNTYyOUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%232c7cbf&color=%23A79B8E" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+## Mailing Lists
+
+Iceberg has four mailing lists:
+
+* **Developers**: <dev@iceberg.apache.org> -- used for community discussions
+    - [Subscribe](mailto:dev-subscribe@iceberg.apache.org)
+    - [Unsubscribe](mailto:dev-unsubscribe@iceberg.apache.org)
+    - [Archive](https://lists.apache.org/list.html?dev@iceberg.apache.org)
+* **Commits**: <commits@iceberg.apache.org> -- distributes commit notifications
+    - [Subscribe](mailto:commits-subscribe@iceberg.apache.org)
+    - [Unsubscribe](mailto:commits-unsubscribe@iceberg.apache.org)
+    - [Archive](https://lists.apache.org/list.html?commits@iceberg.apache.org)
+* **Issues**: <issues@iceberg.apache.org> -- Github issue tracking
+    - [Subscribe](mailto:issues-subscribe@iceberg.apache.org)
+    - [Unsubscribe](mailto:issues-unsubscribe@iceberg.apache.org)
+    - [Archive](https://lists.apache.org/list.html?issues@iceberg.apache.org)
+* **Private**: <private@iceberg.apache.org> -- private list for the PMC to discuss sensitive issues related to the health of the project
+    - [Archive](https://lists.apache.org/list.html?private@iceberg.apache.org)
+
 ## Community Guidelines
 
 ### Apache Iceberg Community Guidelines
@@ -56,43 +106,3 @@ Recruitment of community members should not be conducted through direct messages
 related to contributing to or using Iceberg can be posted to the `#jobs` channel. 
 
 For questions regarding any of the guidelines above, please contact a PMC member
-
-
-## Contribute
-
-See [Contributing](../../../contribute) for more details on how to contribute to Iceberg.
-
-## Issues
-
-Issues are tracked in GitHub:
-
-* [View open issues][open-issues]
-* [Open a new issue][new-issue]
-
-[open-issues]: https://github.com/apache/iceberg/issues
-[new-issue]: https://github.com/apache/iceberg/issues/new
-
-## Slack
-
-We use the [Apache Iceberg workspace](https://apache-iceberg.slack.com/) on Slack. To be invited, follow [this invite link](https://join.slack.com/t/apache-iceberg/shared_invite/zt-1uva9gyp1-TrLQl7o~nZ5PsTVgl6uoEQ).
-
-Please note that this link may occasionally break when Slack does an upgrade. If you encounter problems using it, please let us know by sending an email to <dev@iceberg.apache.org>.
-
-## Mailing Lists
-
-Iceberg has four mailing lists:
-
-* **Developers**: <dev@iceberg.apache.org> -- used for community discussions
-    - [Subscribe](mailto:dev-subscribe@iceberg.apache.org)
-    - [Unsubscribe](mailto:dev-unsubscribe@iceberg.apache.org)
-    - [Archive](https://lists.apache.org/list.html?dev@iceberg.apache.org)
-* **Commits**: <commits@iceberg.apache.org> -- distributes commit notifications
-    - [Subscribe](mailto:commits-subscribe@iceberg.apache.org)
-    - [Unsubscribe](mailto:commits-unsubscribe@iceberg.apache.org)
-    - [Archive](https://lists.apache.org/list.html?commits@iceberg.apache.org)
-* **Issues**: <issues@iceberg.apache.org> -- Github issue tracking
-    - [Subscribe](mailto:issues-subscribe@iceberg.apache.org)
-    - [Unsubscribe](mailto:issues-unsubscribe@iceberg.apache.org)
-    - [Archive](https://lists.apache.org/list.html?issues@iceberg.apache.org)
-* **Private**: <private@iceberg.apache.org> -- private list for the PMC to discuss sensitive issues related to the health of the project
-    - [Archive](https://lists.apache.org/list.html?private@iceberg.apache.org)


### PR DESCRIPTION
Pulling the community guidelines down so that the fun stuff like events, collab, Slack, and mailing lists are more visible. Eventually, we should get these on distinct pages.

![image](https://github.com/apache/iceberg-docs/assets/8547669/ea36f242-342a-4672-97d9-2f9a074dee21)
