### PR TITLE
Docs: Hive and Iceberg quickstart

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -37,7 +37,9 @@ home = [ "HTML", "RSS", "SearchIndex" ]
     { name = "0.12.1", pre = "relative", url = "../0.12.1", weight = 1000 }
   ]
   topnav = [
-    { name = "Quickstart", pre = "relative", url = "../../spark-quickstart", weight = 100 },
+    { name = "Quickstart", weight = 100 },
+    { name = "Hive", parent = "Quickstart", pre = "relative", url = "../../hive-quickstart", weight = 100 },
+    { name = "Spark", parent = "Quickstart", pre = "relative", url = "../../spark-quickstart", weight = 200 },
     { name = "Docs", pre = "relative", url = "../../docs/latest", weight = 200 },
     { name = "Releases", pre = "relative", url = "../../releases", weight = 600 },
     { name = "Blogs", pre = "relative", url = "../../blogs", weight = 998 },

--- a/docs/content/hive-getting-started.md
+++ b/docs/content/hive-getting-started.md
@@ -1,0 +1,118 @@
+---
+title: "Hive and Iceberg Quickstart"
+weight: 100
+url: hive-quickstart
+aliases:
+    - "quickstart"
+    - "quickstarts"
+    - "getting-started"
+disableSidebar: true
+disableToc: true
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+<!-- {{% quickstarts %}} -->
+
+## Hive and Iceberg Quickstart
+
+This guide will get you up and running with an Iceberg and Hive environment, including sample code to
+highlight some powerful features. You can learn more about Iceberg's Hive runtime by checking out the [Hive](../docs/latest/hive/) section.
+
+- [Feature-support](#feature-support)
+- [Enabling Iceberg support in Hive](#enabling-iceberg-support-in-hive)
+- [Catalog Management](#catalog-management)
+- [DDL Commands](#ddl-commands)
+- [DML Commands](#dml-commands)
+
+### Docker images
+
+The fastest way to get started is to use [Apache Hive images](https://hub.docker.com/r/apache/hive) 
+which provides a SQL-like interface to create and query Iceberg tables from your laptop. You need to install the [Docker Desktop](https://www.docker.com/products/docker-desktop/), choosing the Intel or Apple M1 chip if you have a Mac, or choosing Linux.
+
+Set the version variable:
+```export HIVE_VERSION=4.0.0-alpha-2```
+
+Start the container, using the option --platform linux/amd64 for a Mac M1:
+```docker run -d --platform linux/amd64 -p 10000:10000 -p 10002:10002 --env SERVICE_NAME=hiveserver2 --name hive4 apache/hive:${HIVE_VERSION}
+```
+
+This command configures Hive to use the embedded derby database for Hive Metastore. Hive Metastore functions as the Iceberg catalog to locate Iceberg files, which can be anywhere. 
+
+Give HS2 a little time to come up in the docker container, and then start Hive using beeline as follows:
+```docker exec -it hive4 beeline -u 'jdbc:hive2://localhost:10000/'
+```
+
+The hive prompt appears:
+```0: jdbc:hive2://localhost:10000>
+```
+
+You can now run SQL queries, such as ```show databases;```, create Iceberg tables, and query the tables.
+
+### Creating a table
+
+To create your first Iceberg table in Hive, run a [`CREATE TABLE`](../hive#create-table) command. Let's create a table
+using `nyc.taxis` where `nyc` is the database name and `taxis` is the table name.
+
+```sql
+CREATE DATABASE nyc;
+```
+
+```sql
+CREATE TABLE nyc.taxis
+(
+  trip_id bigint,
+  trip_distance float,
+  fare_amount double,
+  store_and_fwd_flag string
+)
+PARTITIONED BY (vendor_id bigint) STORED BY ICEBERG;
+```
+Iceberg catalogs support the full range of SQL DDL commands, including:
+
+* [`CREATE TABLE ... PARTITIONED BY`](../hive#create-table)
+* [`CREATE TABLE ... AS SELECT`](../hive#create-table-as-select)
+* [`CREATE TABLE ... LIKE`](../hive/#create-table-like-table)
+* [`ALTER TABLE`](../hive#alter-table)
+* [`DROP TABLE`](../hive#drop-table)
+
+### Writing Data to a Table
+
+After your table is created, you can insert records.
+
+```sql
+INSERT INTO nyc.taxis
+VALUES (1000371, 1.8, 15.32, 'N', 1), (1000372, 2.5, 22.15, 'N', 2), (1000373, 0.9, 9.01, 'N', 2), (1000374, 8.4, 42.13, 'Y', 1);
+```
+
+### Reading Data from a Table
+
+To read a table, simply use the Iceberg table's name.
+
+```sql
+SELECT * FROM nyc.taxis;
+```
+
+### Next steps
+
+#### Adding Iceberg to Hive
+
+If you already have a Hive 4.0.0-alpha-1, or later, environment, it comes with the Iceberg 0.13.1 included. No additional downloads or jars are needed. If you have a Hive 2.3.x or Hive 3.1.x environment see [`Enabling Iceberg support in Hive`](../hive##enabling-iceberg-support-in-hive).
+
+#### Learn More
+
+To learn more about setting up a database other than Derby, see [Apache Hive Quick Start](https://hive.apache.org/developement/quickstart/). You can also [set up a standalone metastore, HS2 and Postgres](https://github.com/apache/hive/blob/master/packaging/src/docker/docker-compose.yml). Now that you're up an running with Iceberg and Hive, check out the [Iceberg-Hive docs](../docs/latest/hive/) to learn more!

--- a/landing-page/config.toml
+++ b/landing-page/config.toml
@@ -47,7 +47,9 @@ home = [ "HTML", "RSS", "SearchIndex" ]
     { name = "0.12.1", url = "/docs/0.12.1", weight = 1000 }
   ]
   topnav = [
-    { name = "Quickstart", url = "/spark-quickstart", weight = 100 },
+    { name = "Quickstart", weight = 100 },
+    { name = "Hive", parent = "Quickstart", url = "/hive-quickstart", weight = 100 },
+    { name = "Spark", parent = "Quickstart", url = "/spark-quickstart", weight = 200 },
     { name = "Docs", url = "/docs/latest", weight = 200 },
     { name = "Releases", url = "/releases", weight = 600 },
     { name = "Roadmap", url = "/roadmap", weight = 997 },

--- a/landing-page/content/common/hive-quickstart.md
+++ b/landing-page/content/common/hive-quickstart.md
@@ -33,45 +33,53 @@ disableToc: true
 This guide will get you up and running with an Iceberg and Hive environment, including sample code to
 highlight some powerful features. You can learn more about Iceberg's Hive runtime by checking out the [Hive](../docs/latest/hive/) section.
 
-- [Feature-support](#feature-support)
-- [Enabling Iceberg support in Hive](#enabling-iceberg-support-in-hive)
-- [Catalog Management](#catalog-management)
-- [DDL Commands](#ddl-commands)
-- [DML Commands](#dml-commands)
+- [Docker Images](#docker-images)
+- [Creating a Table](#creating-a-table)
+- [Writing Data to a Table](#writing-data-to-a-table)
+- [Reading Data from a Table](#reading-data-from-a-table)
+- [Next Steps](#next-steps)
 
-### Docker images
+### Docker Images
 
 The fastest way to get started is to use [Apache Hive images](https://hub.docker.com/r/apache/hive) 
-which provides a SQL-like interface to create and query Iceberg tables from your laptop. You need to install the [Docker Desktop](https://www.docker.com/products/docker-desktop/), choosing the Intel or Apple M1 chip if you have a Mac, or choosing Linux.
+which provides a SQL-like interface to create and query Iceberg tables from your laptop. You need to install the [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
-Set the version variable:
-```export HIVE_VERSION=4.0.0-alpha-2```
+Take a look at the Tags tab in [Apache Hive docker images](https://hub.docker.com/r/apache/hive/tags?page=1&ordering=-last_updated) to see the available Hive versions.
 
-Start the container, using the option --platform linux/amd64 for a Mac M1:
-```docker run -d --platform linux/amd64 -p 10000:10000 -p 10002:10002 --env SERVICE_NAME=hiveserver2 --name hive4 apache/hive:${HIVE_VERSION}
+Set the version variable. For example:
+```sh
+export HIVE_VERSION=4.0.0-alpha-2
 ```
 
-This command configures Hive to use the embedded derby database for Hive Metastore. Hive Metastore functions as the Iceberg catalog to locate Iceberg files, which can be anywhere. 
+Start the container, using the option --platform linux/amd64 for a Mac with an M-Series chip:
+```sh
+docker run -d --platform linux/amd64 -p 10000:10000 -p 10002:10002 --env SERVICE_NAME=hiveserver2 --name hive4 apache/hive:${HIVE_VERSION}
+```
 
-Give HS2 a little time to come up in the docker container, and then start Hive using beeline as follows:
-```docker exec -it hive4 beeline -u 'jdbc:hive2://localhost:10000/'
+The docker run command above configures Hive to use the embedded derby database for Hive Metastore. Hive Metastore functions as the Iceberg catalog to locate Iceberg files, which can be anywhere. 
+
+Give HiveServer (HS2) a little time to come up in the docker container, and then start the Hive Beeline client using the following command to connect with the HS2 containers you already started:
+```sh
+docker exec -it hive4 beeline -u 'jdbc:hive2://localhost:10000/'
 ```
 
 The hive prompt appears:
-```0: jdbc:hive2://localhost:10000>
+```sh
+0: jdbc:hive2://localhost:10000>
 ```
 
-You can now run SQL queries, such as ```show databases;```, create Iceberg tables, and query the tables.
+You can now run SQL queries to create Iceberg tables and query the tables. For example:
+```sql
+show databases;
+```
 
-### Creating a table
+### Creating a Table
 
 To create your first Iceberg table in Hive, run a [`CREATE TABLE`](../hive#create-table) command. Let's create a table
 using `nyc.taxis` where `nyc` is the database name and `taxis` is the table name.
-
 ```sql
 CREATE DATABASE nyc;
 ```
-
 ```sql
 CREATE TABLE nyc.taxis
 (
@@ -84,16 +92,15 @@ PARTITIONED BY (vendor_id bigint) STORED BY ICEBERG;
 ```
 Iceberg catalogs support the full range of SQL DDL commands, including:
 
-* [`CREATE TABLE ... PARTITIONED BY`](../hive#create-table)
-* [`CREATE TABLE ... AS SELECT`](../hive#create-table-as-select)
-* [`CREATE TABLE ... LIKE`](../hive/#create-table-like-table)
+* [`CREATE TABLE`](../hive#create-table)
+* [`CREATE TABLE AS SELECT`](../hive#create-table-as-select)
+* [`CREATE TABLE LIKE TABLE`](../hive#create-table-like-table)
 * [`ALTER TABLE`](../hive#alter-table)
 * [`DROP TABLE`](../hive#drop-table)
 
 ### Writing Data to a Table
 
 After your table is created, you can insert records.
-
 ```sql
 INSERT INTO nyc.taxis
 VALUES (1000371, 1.8, 15.32, 'N', 1), (1000372, 2.5, 22.15, 'N', 2), (1000373, 0.9, 9.01, 'N', 2), (1000374, 8.4, 42.13, 'Y', 1);
@@ -102,7 +109,6 @@ VALUES (1000371, 1.8, 15.32, 'N', 1), (1000372, 2.5, 22.15, 'N', 2), (1000373, 0
 ### Reading Data from a Table
 
 To read a table, simply use the Iceberg table's name.
-
 ```sql
 SELECT * FROM nyc.taxis;
 ```
@@ -111,7 +117,7 @@ SELECT * FROM nyc.taxis;
 
 #### Adding Iceberg to Hive
 
-If you already have a Hive 4.0.0-alpha-1, or later, environment, it comes with the Iceberg 0.13.1 included. No additional downloads or jars are needed. If you have a Hive 2.3.x or Hive 3.1.x environment see [`Enabling Iceberg support in Hive`](../hive##enabling-iceberg-support-in-hive).
+If you already have a Hive 4.0.0-alpha-1, or later, environment, it comes with the Iceberg 0.13.1 included. No additional downloads or jars are needed. If you have a Hive 2.3.x or Hive 3.1.x environment see [`Enabling Iceberg support in Hive`](../hive#enabling-iceberg-support-in-hive).
 
 #### Learn More
 

--- a/landing-page/content/common/hive-quickstart.md
+++ b/landing-page/content/common/hive-quickstart.md
@@ -121,4 +121,4 @@ If you already have a Hive 4.0.0-alpha-1, or later, environment, it comes with t
 
 #### Learn More
 
-To learn more about setting up a database other than Derby, see [Apache Hive Quick Start](https://hive.apache.org/developement/quickstart/). You can also [set up a standalone metastore, HS2 and Postgres](https://github.com/apache/hive/blob/master/packaging/src/docker/docker-compose.yml). Now that you're up an running with Iceberg and Hive, check out the [Iceberg-Hive docs](../docs/latest/hive/) to learn more!
+To learn more about setting up a database other than Derby, see [Apache Hive Quick Start](https://hive.apache.org/developement/quickstart/). You can also [set up a standalone metastore, HS2 and Postgres](https://github.com/apache/hive/blob/master/packaging/src/docker/docker-compose.yml). Now that you're up and running with Iceberg and Hive, check out the [Iceberg-Hive docs](../docs/latest/hive/) to learn more!

--- a/landing-page/content/common/hive-quickstart.md
+++ b/landing-page/content/common/hive-quickstart.md
@@ -46,12 +46,12 @@ which provides a SQL-like interface to create and query Iceberg tables from your
 
 Take a look at the Tags tab in [Apache Hive docker images](https://hub.docker.com/r/apache/hive/tags?page=1&ordering=-last_updated) to see the available Hive versions.
 
-Set the version variable. For example:
+Set the version variable.
 ```sh
 export HIVE_VERSION=4.0.0-alpha-2
 ```
 
-Start the container, using the option --platform linux/amd64 for a Mac with an M-Series chip:
+Start the container, using the option `--platform linux/amd64` for a Mac with an M-Series chip:
 ```sh
 docker run -d --platform linux/amd64 -p 10000:10000 -p 10002:10002 --env SERVICE_NAME=hiveserver2 --name hive4 apache/hive:${HIVE_VERSION}
 ```
@@ -68,7 +68,7 @@ The hive prompt appears:
 0: jdbc:hive2://localhost:10000>
 ```
 
-You can now run SQL queries to create Iceberg tables and query the tables. For example:
+You can now run SQL queries to create Iceberg tables and query the tables.
 ```sql
 show databases;
 ```
@@ -117,7 +117,7 @@ SELECT * FROM nyc.taxis;
 
 #### Adding Iceberg to Hive
 
-If you already have a Hive 4.0.0-alpha-1, or later, environment, it comes with the Iceberg 0.13.1 included. No additional downloads or jars are needed. If you have a Hive 2.3.x or Hive 3.1.x environment see [`Enabling Iceberg support in Hive`](../hive#enabling-iceberg-support-in-hive).
+If you already have a Hive 4.0.0-alpha-1, or later, environment, it comes with the Iceberg 0.13.1 included. No additional downloads or jars are needed. If you have a Hive 2.3.x or Hive 3.1.x environment see [Enabling Iceberg support in Hive](../hive#enabling-iceberg-support-in-hive).
 
 #### Learn More
 


### PR DESCRIPTION
The Hive and Iceberg Quickstart complements the Spark and Iceberg Quickstart, has the look-and-feel and equivalent content.