### PR TITLE
Add 1.3.1 to latest

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -24,6 +24,7 @@ home = [ "HTML", "RSS", "SearchIndex" ]
 [menu]
   versions = [
     { name = "latest", pre = "relative", url = "../latest", weight = 1 },
+    { name = "1.3.1", pre = "relative", url = "../1.3.1", weight = 989 },
     { name = "1.3.0", pre = "relative", url = "../1.3.0", weight = 990 },
     { name = "1.2.1", pre = "relative", url = "../1.2.1", weight = 991 },
     { name = "1.2.0", pre = "relative", url = "../1.2.0", weight = 992 },


### PR DESCRIPTION
Looks like 1.3.1 is missing:

![image](https://github.com/apache/iceberg-docs/assets/1134248/69d82bea-97e1-4067-b623-dd8069c4e342)
