### PR TITLE
Update Hive quickstart version

### DIFF
--- a/landing-page/content/common/hive-quickstart.md
+++ b/landing-page/content/common/hive-quickstart.md
@@ -48,7 +48,7 @@ Take a look at the Tags tab in [Apache Hive docker images](https://hub.docker.co
 
 Set the version variable.
 ```sh
-export HIVE_VERSION=4.0.0-alpha-2
+export HIVE_VERSION=4.0.0-beta-1
 ```
 
 Start the container, using the option `--platform linux/amd64` for a Mac with an M-Series chip:


### PR DESCRIPTION
beta-1 comes with 1.3.0, and alpha-2 with 0.14.0, so good to bump it