### PR TITLE
Remove ASF publish property

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,6 +34,3 @@ notifications:
     commits:      commits@iceberg.apache.org
     issues:       issues@iceberg.apache.org
     pullrequests: issues@iceberg.apache.org
-
-publish:
-    whoami:  asf-site


### PR DESCRIPTION
This PR undoes PR #36 as the site will now be maintained in the main repository.

See: apache/iceberg#9520