### PR TITLE
Remove publish directive from .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,6 +32,3 @@ notifications:
     commits:      commits@iceberg.apache.org
     issues:       issues@iceberg.apache.org
     pullrequests: issues@iceberg.apache.org
-
-publish:
-    whoami:  asf-site


### PR DESCRIPTION
Remove publish directive from .asf.yaml as we're moving back to the iceberg/main repository to host the site.